### PR TITLE
Package project as a Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726463316,
+        "narHash": "sha256-gI9kkaH0ZjakJOKrdjaI/VbaMEo9qBbSUl93DnU7f4c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-old": {
+      "locked": {
+        "lastModified": 1716651315,
+        "narHash": "sha256-iMgzIeedMqf30TXZ439zW3Yvng1Xm9QTGO+ZwG1IWSw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c5187508b11177ef4278edf19616f44f21cc8c69",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c5187508b11177ef4278edf19616f44f21cc8c69",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-old": "nixpkgs-old"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Telegram client for the terminal written in Rust.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # contains tdlib 1.8.29
+    nixpkgs-old.url = "github:NixOS/nixpkgs/c5187508b11177ef4278edf19616f44f21cc8c69";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      nixpkgs-old,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        pkgs-old = import nixpkgs-old { inherit system; };
+      in
+      {
+        packages = rec {
+          tgt = pkgs.rustPlatform.buildRustPackage {
+            pname = "tgt";
+            version = "1.0.0";
+            src = ./.;
+            cargoHash = "sha256-val5GoLPDo6uuJUpXWeEuvmw6+GuqtQszoY/3lO2JSQ=";
+            buildNoDefaultFeatures = true;
+            buildFeatures = [ "pkg-config" ];
+
+            nativeBuildInputs = with pkgs; [ pkg-config ];
+            buildInputs = [
+              pkgs.openssl
+              pkgs-old.tdlib
+            ];
+
+            configurePhase = ''
+              runHook preConfigure
+              export HOME=$(mktemp -d)
+              runHook postConfigure
+            '';
+          };
+
+          default = tgt;
+        };
+      }
+    );
+}


### PR DESCRIPTION
Adds a `flake.nix` file to package the project as a Nix flake.

The project can be built through nix by running `nix build`. **Note:** currently building the project does not work. See below.

## Issues with merging

There is still an issue with actually building the package since `tgt` requires that there is a `.tgt/config` directory in Home. This is currently achieved in the build script, but Nix does not allow modifying any directories other than special directories relevant to the build process. As such generating/copying the config files should be moved to the app itself, and generation happen on first launch.

resolves: https://github.com/FedericoBruzzone/tgt/issues/76
