### PR TITLE
Add flake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 /.log
 /.logs
 /.vscode
+result
+outputs/
+result-*
+result
+.direnv
+.envrc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -64,6 +64,69 @@ After the installation, you can run `tgt` with the following command:
 tgt --help
 ```
 
+**From `flake.nix`**
+
+First, create the required TOML configuration files in `~/.tgt/config` using these commands:
+
+```bash
+git clone https://github.com/FedericoBruzzone/tgt ~/tgt
+mkdir -p ~/.tgt/config
+cp ~/tgt/config/* ~/.tgt/config
+```
+
+After setting up the configuration files, you have two installation options:
+
+1. Run directly with `nix run`:
+
+```bash
+nix run github:FedericoBruzzone/tgt
+```
+
+2. Add `tgt` to your system packages:
+
+Add the following to your `flake.nix`:
+
+```nix
+{
+  inputs = {
+    tgt.url = "github:FedericoBruzzone/tgt";
+    tgt.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { tgt, ... }
+}
+```
+
+Then add it to your `environment.systemPackages`:
+
+```nix
+{pkgs, tgt, ...}: {
+  environment = {
+    systemPackages = [
+        (tgt.packages.${pkgs.system}.default)
+    ];
+  };
+}
+```
+
+To use a specific version of the program, override the `src` attribute:
+
+```nix
+{pkgs, tgt, ...}: {
+  environment = {
+    systemPackages = [
+      (tgt.packages.${pkgs.system}.default.overrideAttrs (old: {
+        src = pkgs.fetchFromGitHub {
+          owner = old.src.owner;
+          repo = old.src.repo;
+          rev = "00000000000000000000000000000000000000";
+          sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        };
+      }))
+    ];
+  };
+}
+```
 
 ### Configuration
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729880355,
+        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    inputs:
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      forEachSystem = inputs.nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forEachSystem (
+        system:
+        let
+          pkgs = inputs.nixpkgs.legacyPackages.${system};
+          inherit (pkgs) lib;
+          inherit (pkgs.darwin.apple_sdk) frameworks;
+          inherit (pkgs.stdenvNoCC.hostPlatform) isDarwin;
+          tdlib = pkgs.tdlib.overrideAttrs {
+            version = "1.8.29";
+            src = pkgs.fetchFromGitHub {
+              owner = "tdlib";
+              repo = "td";
+              rev = "af69dd4397b6dc1bf23ba0fd0bf429fcba6454f6";
+              hash = "sha256-2RhKSxy0AvuA74LHI86pqUxv9oJZ+ZxxDe4TPI5UYxE=";
+            };
+          };
+          rlinkLibs = builtins.attrValues {
+            inherit (pkgs)
+              pkg-config
+              openssl
+              ;
+            inherit tdlib;
+          };
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "tgt";
+            version = "unstable-2024-10-21";
+            src = pkgs.fetchFromGitHub {
+              owner = "FedericoBruzzone";
+              repo = "tgt";
+              rev = "470b6052dd66ff55f6039bbf940902f503fb67e2";
+              sha256 = "sha256-TDxzQpir9KY6rl34YJ5IHFjfMRYzbGlPI58M9i+G9+Y=";
+            };
+
+            nativeBuildInputs = rlinkLibs;
+
+            buildInputs =
+              rlinkLibs
+              ++ lib.optional isDarwin (
+                builtins.attrValues {
+                  inherit (frameworks)
+                    AppKit
+                    CoreGraphics
+                    Security
+                    SystemConfiguration
+                    ;
+                }
+              );
+
+            patches = [ ./patches/0001-check-filesystem-writability-before-operations.patch ];
+
+            # Tests are broken on nix
+            doCheck = false;
+
+            cargoHash = "sha256-QqvP/ULAEn+N8w01kDq4pltP4xHoUhNJPZgP/76hhBo=";
+            buildNoDefaultFeatures = true;
+            buildFeatures = [ "pkg-config" ];
+
+            env = {
+              RUSTFLAGS = "-C link-arg=-Wl,-rpath,${tdlib}/lib -L ${pkgs.openssl}/lib";
+              LOCAL_TDLIB_PATH = "${tdlib}/lib";
+            };
+
+            meta = {
+              description = "TUI for Telegram written in Rust";
+              homepage = "https://github.com/FedericoBruzzone/tgt";
+              license = lib.licenses.free;
+              maintainers = with lib.maintainers; [ donteatoreo ];
+            };
+          };
+        }
+      );
+    };
+}

--- a/patches/0001-check-filesystem-writability-before-operations.patch
+++ b/patches/0001-check-filesystem-writability-before-operations.patch
@@ -1,0 +1,35 @@
+diff --git a/build.rs b/build.rs
+index e211e5b..3da6109 100644
+--- a/build.rs
++++ b/build.rs
+@@ -1,3 +1,7 @@
++fn is_writable<P: AsRef<std::path::Path>>(path: P) -> bool {
++    std::fs::OpenOptions::new().write(true).open(path).is_ok()
++}
++
+ fn empty_tgt_folder() {
+     let home = dirs::home_dir().unwrap().to_str().unwrap().to_owned();
+     let _ = std::fs::remove_dir_all(format!("{}/.tgt/config", home));
+@@ -24,11 +28,18 @@ fn main() -> std::io::Result<()> {
+         return Ok(());
+     }
+
+-    empty_tgt_folder();
+-    move_config_folder_to_home_dottgt();
+     let home = dirs::home_dir().unwrap().to_str().unwrap().to_owned();
+-    let dest = format!("{}/.tgt/tdlib", home);
+-    tdlib_rs::build::build(Some(dest));
++    let tgt_config_path = format!("{}/.tgt/config", home);
++
++    if is_writable(&tgt_config_path) {
++        empty_tgt_folder();
++        move_config_folder_to_home_dottgt();
++        let dest = format!("{}/.tgt/tdlib", home);
++        tdlib_rs::build::build(Some(dest));
++    } else {
++        eprintln!("Filesystem is read-only. Skipping file operations.");
++        tdlib_rs::build::build(None);
++    }
+
+     Ok(())
+ }


### PR DESCRIPTION
Closes #76 

Context: https://github.com/FedericoBruzzone/tgt/pull/77#issuecomment-2440334310

About these lines:

```nix
src = pkgs.fetchFromGitHub {
  owner = "FedericoBruzzone";
  repo = "tgt";
  rev = "470b6052dd66ff55f6039bbf940902f503fb67e2";
  sha256 = "sha256-VO1KdAgx0hLYEegyotBO8eLPbA33KKEoanZRLqQCiHI=";
};
```

The reason I'm pinning to a specific commit is that:

1. We're using `cargoHash`, which produces an exact hash of all the dependencies *(plus other factors, e.g., `pname`)*, so any changes to the `Cargo.lock` will result in a completely different hash and be unable to build the flake.
2. The `flake.nix` relies on a patch to fix `build.rs` in order to work properly on Nix
3. I can only guarantee the functioning of the program and the successful build of that program for that commit right now, so leaving it as `src = ./.;` would just mean it breaks in the future and breaks the reproducible "promise"

I do not plan on adding support for a `devShell` as I don't know how to write Rust code or have any meaningful knowledge in Rust; thus, I can't guarantee a proper `devShell` experience

Although I would imagine anyone familiar with Nix who wants to develop this project would most likely have the know-how to add `devShell` support themselves better than I could.

Currently, it builds and runs on `x86_64-linux` and `aarch64-darwin`. I don't own an `aarch64-linux` or `x86_64-darwin` machine, but theoretically, they shouldn't have any issues either.