### PR TITLE
Vim keymap fix

### DIFF
--- a/docs/vim_keymap.toml
+++ b/docs/vim_keymap.toml
@@ -7,11 +7,11 @@ keymap = [
   # Quit the application
   { keys = ["ctrl+c"], command = "try_quit", description = "Quit the application"},
   # Focus the chat list
-  { keys = ["1"], command = "focus_chat_list", description = "Focus the chat list"},
+  { keys = ["alt+1"], command = "focus_chat_list", description = "Focus the chat list"},
   # Focus the chat
-  { keys = ["2"], command = "focus_chat", description = "Focus the chat"},
+  { keys = ["alt+2"], command = "focus_chat", description = "Focus the chat"},
   # Focus the prompt
-  { keys = ["3"], command = "focus_prompt", description = "Focus the prompt"},
+  { keys = ["alt+3"], command = "focus_prompt", description = "Focus the prompt"},
   # Unfocus the current component
   { keys = ["esc"], command = "unfocus_component", description = "Unfocus the current component"},
   # Toggle chat_list visibility


### PR DESCRIPTION
Changes vim keymap to allow to enter digits from 1 to 3 in the prompt and avoiding crashes when switching focus.

Resolves: #83