### PR TITLE
Add the ability to sort the chat list window through a search string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,6 +1805,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,6 +3036,7 @@ dependencies = [
  "futures",
  "image",
  "lazy_static",
+ "nucleo-matcher",
  "ratatui",
  "ratatui-image",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,14 +60,13 @@ ratatui-image = "5.0.0"
 image = "0.25.6"
 signal-hook = "0.3.17"
 clap = { version = "4.5.35", features = ["derive"] }
+nucleo-matcher = "0.3.1"
 
 [build-dependencies]
 dirs = "6.0.0"
 reqwest = { version = "0.12.15", features = ["blocking"] }
 zip = { version = "2.3.0" }
 tdlib-rs = "1.0.5"
-
-[profile.dev]
 
 [profile.release]
 lto = true

--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -48,6 +48,7 @@ keymap = [
   # Open the selected chat
   { keys = ["enter"], command = "chat_list_open", description = "Open the selected chat"},
   { keys = ["alt+r"], command = "chat_list_search", description = "Focus on prompt to start searching"},
+  { keys = ["alt+c"], command = "chat_list_restore_sort", description = "Restore the default ordering of the chat list"},
 ]
 
 # The chat key bindings are only usable in the chat component.

--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -47,6 +47,7 @@ keymap = [
   { keys = ["right"], command = "chat_list_open", description = "Open the selected chat"},
   # Open the selected chat
   { keys = ["enter"], command = "chat_list_open", description = "Open the selected chat"},
+  { keys = ["alt+r"], command = "chat_list_search", description = "Focus on prompt to start searching"},
 ]
 
 # The chat key bindings are only usable in the chat component.

--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -47,7 +47,9 @@ keymap = [
   { keys = ["right"], command = "chat_list_open", description = "Open the selected chat"},
   # Open the selected chat
   { keys = ["enter"], command = "chat_list_open", description = "Open the selected chat"},
+  # Move focus to the prompt and set its state to receive a string used to order the entries in the chat list window.
   { keys = ["alt+r"], command = "chat_list_search", description = "Focus on prompt to start searching"},
+  # Restore the default sorting in the chat list window.
   { keys = ["alt+c"], command = "chat_list_restore_sort", description = "Restore the default ordering of the chat list"},
 ]
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -143,6 +143,8 @@ pub enum Action {
     ChatListUnselect,
     /// ChatListOpen action.
     ChatListOpen,
+    /// ChatListSortWithString action.
+    ChatListSortWithString(String),
 
     /// ChatWindowNext action.
     ChatWindowNext,
@@ -169,6 +171,10 @@ pub enum Action {
     /// This event is used to reply to a message.
     /// The first parameter is the `message_id` and the second parameter is the `text`.
     ReplyMessage(i64, String),
+    /// ChatListSearch event.
+    /// This event is used to set the prompt to search to set the search string
+    /// for the ChatListWindow.
+    ChatListSearch,
 }
 /// Implement the `Action` enum.
 impl Action {
@@ -207,6 +213,7 @@ impl FromStr for Action {
             "chat_list_previous" => Ok(Action::ChatListPrevious),
             "chat_list_unselect" => Ok(Action::ChatListUnselect),
             "chat_list_open" => Ok(Action::ChatListOpen),
+            "chat_list_search" => Ok(Action::ChatListSearch),
             "chat_window_next" => Ok(Action::ChatWindowNext),
             "chat_window_previous" => Ok(Action::ChatWindowPrevious),
             "chat_window_unselect" => Ok(Action::ChatWindowUnselect),

--- a/src/action.rs
+++ b/src/action.rs
@@ -175,6 +175,10 @@ pub enum Action {
     /// This event is used to set the prompt to search to set the search string
     /// for the ChatListWindow.
     ChatListSearch,
+    /// ChatListRestoreSort event.
+    /// This event is used to restore the default ordering.
+    /// I.e. pinned first then chronological order.
+    ChatListRestoreSort,
 }
 /// Implement the `Action` enum.
 impl Action {
@@ -214,6 +218,7 @@ impl FromStr for Action {
             "chat_list_unselect" => Ok(Action::ChatListUnselect),
             "chat_list_open" => Ok(Action::ChatListOpen),
             "chat_list_search" => Ok(Action::ChatListSearch),
+            "chat_list_restore_sort" => Ok(Action::ChatListRestoreSort),
             "chat_window_next" => Ok(Action::ChatWindowNext),
             "chat_window_previous" => Ok(Action::ChatWindowPrevious),
             "chat_window_unselect" => Ok(Action::ChatWindowUnselect),

--- a/src/components/chat_list_window.rs
+++ b/src/components/chat_list_window.rs
@@ -12,7 +12,6 @@ use ratatui::widgets::block::{Block, Title};
 use ratatui::widgets::Borders;
 use ratatui::widgets::{List, ListDirection, ListState};
 use ratatui::Frame;
-use std::cmp::Ordering;
 use std::sync::Arc;
 use tdlib_rs::enums::{ChatList, UserStatus};
 use tdlib_rs::types::User;
@@ -249,11 +248,12 @@ impl ChatListWindow {
         }
     }
 
+    /// Sets the string used to order the entries of the chat list.
     fn sort(&mut self, s: String) {
-        // TODO Does not panic and
         self.sort_string = Some(s);
     }
 
+    /// Unsets the string used to order the entries of the chat list.
     fn default_sort(&mut self) {
         self.sort_string = None;
     }
@@ -323,11 +323,7 @@ impl Component for ChatListWindow {
                             &mut Vec::new(),
                         )
                         .unwrap_or(0);
-                    match (a_score, b_score) {
-                        (a, b) if a < b => Ordering::Less,
-                        (a, b) if a > b => Ordering::Greater,
-                        _ => Ordering::Equal,
-                    }
+                    a_score.cmp(&b_score)
                 });
                 self.chat_list.reverse();
             }

--- a/src/components/chat_list_window.rs
+++ b/src/components/chat_list_window.rs
@@ -305,32 +305,28 @@ impl Component for ChatListWindow {
                 let mut config = nucleo_matcher::Config::DEFAULT;
                 config.prefer_prefix = true;
                 let mut matcher = Matcher::new(config);
-                let s: Vec<char> = s.chars().map(|c| c as char).collect();
+                let s: Vec<char> = s.chars().collect();
                 self.chat_list.sort_by(|a, b| {
-                    let a: Vec<char> = a.chat_name.chars().map(|c| c as char).collect();
-                    let b: Vec<char> = b.chat_name.chars().map(|c| c as char).collect();
-                    let a_score = match matcher.fuzzy_indices(
-                        Utf32Str::Unicode(&a),
-                        Utf32Str::Unicode(&s),
-                        &mut Vec::new(),
-                    ) {
-                        Some(v) => v,
-                        None => 0,
-                    };
-                    let b_score = match matcher.fuzzy_indices(
-                        Utf32Str::Unicode(&b),
-                        Utf32Str::Unicode(&s),
-                        &mut Vec::new(),
-                    ) {
-                        Some(v) => v,
-                        None => 0,
-                    };
-                    if a_score < b_score {
-                        Ordering::Less
-                    } else if a_score > b_score {
-                        Ordering::Greater
-                    } else {
-                        Ordering::Equal
+                    let a: Vec<char> = a.chat_name.chars().collect();
+                    let b: Vec<char> = b.chat_name.chars().collect();
+                    let a_score = matcher
+                        .fuzzy_indices(
+                            Utf32Str::Unicode(&a),
+                            Utf32Str::Unicode(&s),
+                            &mut Vec::new(),
+                        )
+                        .unwrap_or(0);
+                    let b_score = matcher
+                        .fuzzy_indices(
+                            Utf32Str::Unicode(&b),
+                            Utf32Str::Unicode(&s),
+                            &mut Vec::new(),
+                        )
+                        .unwrap_or(0);
+                    match (a_score, b_score) {
+                        (a, b) if a < b => Ordering::Less,
+                        (a, b) if a > b => Ordering::Greater,
+                        _ => Ordering::Equal,
                     }
                 });
                 self.chat_list.reverse();

--- a/src/components/chat_list_window.rs
+++ b/src/components/chat_list_window.rs
@@ -253,6 +253,10 @@ impl ChatListWindow {
         // TODO Does not panic and
         self.sort_string = Some(s);
     }
+
+    fn default_sort(&mut self) {
+        self.sort_string = None;
+    }
 }
 
 /// Implement the `HandleFocus` trait for the `ChatListWindow` struct.
@@ -282,6 +286,7 @@ impl Component for ChatListWindow {
             Action::ChatListUnselect => self.unselect(),
             Action::ChatListOpen => self.confirm_selection(),
             Action::ChatListSortWithString(s) => self.sort(s),
+            Action::ChatListRestoreSort => self.default_sort(),
             _ => {}
         }
     }

--- a/src/components/core_window.rs
+++ b/src/components/core_window.rs
@@ -255,6 +255,17 @@ impl Component for CoreWindow {
             Action::HideChatWindowReply => {
                 self.show_reply_message = false;
             }
+            Action::ChatListSearch => {
+                self.component_focused = Some(ComponentName::Prompt);
+                self.components
+                    .get_mut(&ComponentName::Prompt)
+                    .unwrap_or_else(|| panic!("Failed to get component: {}", ComponentName::Prompt))
+                    .focus();
+                self.components
+                    .iter_mut()
+                    .filter(|(name, _)| *name != &ComponentName::Prompt)
+                    .for_each(|(_, component)| component.unfocus());
+            }
             _ => {}
         }
 

--- a/src/components/prompt_window.rs
+++ b/src/components/prompt_window.rs
@@ -490,7 +490,6 @@ impl Input {
                     self.mode = Mode::Normal;
                 }
                 Mode::SearchChatList => {
-                    // TODO Proper error handling
                     // Sending a focus first is required for the next action to propagate
                     // to the chat list window.
                     // This should probably change in the future, components should change

--- a/src/components/prompt_window.rs
+++ b/src/components/prompt_window.rs
@@ -490,11 +490,12 @@ impl Input {
                     self.mode = Mode::Normal;
                 }
                 Mode::SearchChatList => {
-                    // Sending a focus first is required for the next action to propagate
-                    // to the chat list window.
-                    // This should probably change in the future, components should change
-                    // state all together when an action is received.
-                    // Refer to the update() method in the CorewWindow struct.
+                    // NOTE: This should probably change in the future. Currently CoreWindow
+                    // only propagates updates to the other components if they are in focus.
+                    // FocusComponent is sent first to work around this problem.
+                    //
+                    // Ideally CoreWindow should propagate updates regardless of focus, that
+                    // way components can handle their own state by themselves.
                     self.action_tx
                         .as_ref()
                         .unwrap()

--- a/src/configs/custom/keymap_custom.rs
+++ b/src/configs/custom/keymap_custom.rs
@@ -439,7 +439,7 @@ mod tests {
     fn test_keymap_config_default() {
         let keymap_config = KeymapConfig::default();
         assert_eq!(keymap_config.core_window.len(), 15);
-        assert_eq!(keymap_config.chat_list.len(), 5);
+        assert_eq!(keymap_config.chat_list.len(), 7);
         assert_eq!(keymap_config.chat.len(), 9);
         assert_eq!(keymap_config.prompt.len(), 0);
     }
@@ -541,7 +541,7 @@ mod tests {
         };
         keymap_config = keymap_config.merge(Some(keymap_raw));
         assert_eq!(keymap_config.core_window.len(), 15);
-        assert_eq!(keymap_config.chat_list.len(), 5);
+        assert_eq!(keymap_config.chat_list.len(), 7);
         assert_eq!(keymap_config.chat.len(), 9);
         assert_eq!(keymap_config.prompt.len(), 0);
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -199,9 +199,7 @@ impl Display for Event {
             Event::ReplyMessage(message_id, text) => {
                 write!(f, "ReplyMessage({}, {})", message_id, text)
             }
-            Event::ViewAllMessages => {
-                write!(f, "ViewAllMessages")
-            }
+            Event::ViewAllMessages => write!(f, "ViewAllMessages"),
         }
     }
 }


### PR DESCRIPTION
Adds the ability to sort chats based on a search string. To do this the PR introduces the `nucleo-matcher` crate which is used to rank chat names using fuzzy search algorithms.