### PR TITLE
Fix: rebase startup-hang-fixes + CI static-download feature

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [aarch64-linux-android, x86_64-linux-android]
-        feature: ["download-tdlib,static", "local-tdlib,static"]
+        feature: ["static-download", "local-tdlib,static"]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [local-tdlib, pkg-config, download-tdlib, "local-tdlib,static", "download-tdlib,static"]
+        feature: [local-tdlib, pkg-config, download-tdlib, static-download, "local-tdlib,static"]
         os: [ubuntu-latest, ubuntu-24.04-arm]
 
     runs-on: ${{ matrix.os }}
@@ -153,7 +153,7 @@ jobs:
       # needs it in LD_LIBRARY_PATH when it runs. Pre-build tdlib-rs so we can locate
       # the lib and set LD_LIBRARY_PATH for the rest of the job.
       - name: Set LD_LIBRARY_PATH for download-tdlib
-        if: contains(matrix.feature, 'download-tdlib')
+        if: contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download'
         run: |
           cargo build --no-default-features --features tdlib-rs/download-tdlib -p tdlib-rs 2>/dev/null || true
           TDLIB_LIB=$(find target -name 'libtdjson*.so*' 2>/dev/null | head -1)
@@ -171,7 +171,7 @@ jobs:
 
       - name: Run cargo clippy
         run: |
-          if [ "${{ matrix.feature }}" = "download-tdlib" ]; then
+          if [ "${{ matrix.feature }}" = "download-tdlib" ] || [ "${{ matrix.feature }}" = "static-download" ]; then
             TDLIB_LIB=$(find target -name 'libtdjson*.so*' 2>/dev/null | head -1)
             if [ -n "$TDLIB_LIB" ]; then
               export LD_LIBRARY_PATH="$(dirname "$TDLIB_LIB"):${LD_LIBRARY_PATH:-}"

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -169,6 +169,7 @@ jobs:
       - name: Ensure OpenSSL/zlib static archives exist in LOCAL_TDLIB_PATH
         if: matrix.feature == 'local-tdlib,static'
         run: |
+          WORKSPACE="$(pwd)"
           if [ ! -d "./tdlib/lib" ]; then
             echo "tdlib/lib not found; did Extract TDLib run?"
             ls -la
@@ -212,7 +213,9 @@ jobs:
               ./configure --static --prefix="$ZLIB_BUILD_DIR/install"
               make -j"$(sysctl -n hw.ncpu)"
               make install
-              cp -f "$ZLIB_BUILD_DIR/install/lib/libz.a" "$GITHUB_WORKSPACE/tdlib/lib/"
+              mkdir -p "$WORKSPACE/tdlib/lib"
+              cp -f "$ZLIB_BUILD_DIR/install/lib/libz.a" "$WORKSPACE/tdlib/lib/"
+              cd "$WORKSPACE"
             fi
           fi
 

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -147,25 +147,6 @@ jobs:
             cp -f "$ZLIB_LIB" "./tdlib/lib/" || true
           fi
 
-      - name: Ensure OpenSSL/zlib static archives exist in LOCAL_TDLIB_PATH
-        if: matrix.feature == 'local-tdlib,static'
-        run: |
-          # This runs after Extract TDLib and before cargo build, so LOCAL_TDLIB_PATH has the archives.
-          if [ ! -d "./tdlib/lib" ]; then
-            echo "tdlib/lib not found; did Extract TDLib run?"
-            ls -la
-            exit 1
-          fi
-          if ls ./tdlib/lib/libssl.a ./tdlib/lib/libcrypto.a ./tdlib/lib/libz.a >/dev/null 2>&1; then
-            ls -la ./tdlib/lib/libssl.a ./tdlib/lib/libcrypto.a ./tdlib/lib/libz.a
-            exit 0
-          fi
-          echo "Static archives missing from ./tdlib/lib; copying from cached td/tdlib/lib"
-          cp -f ./td/tdlib/lib/libssl.a ./tdlib/lib/ || true
-          cp -f ./td/tdlib/lib/libcrypto.a ./tdlib/lib/ || true
-          cp -f ./td/tdlib/lib/libz.a ./tdlib/lib/ || true
-          ls -la ./tdlib/lib || true
-
       - name: Save cache TDLib
         if: steps.cache-tdlib-restore.outputs.cache-hit != 'true' && (contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download')
         uses: actions/cache/save@v5
@@ -185,6 +166,24 @@ jobs:
           cp -r ./td/tdlib ./
           # sudo cp ./tdlib/lib/libtdjson.*.dylib /usr/local/lib/
        
+      - name: Ensure OpenSSL/zlib static archives exist in LOCAL_TDLIB_PATH
+        if: matrix.feature == 'local-tdlib,static'
+        run: |
+          if [ ! -d "./tdlib/lib" ]; then
+            echo "tdlib/lib not found; did Extract TDLib run?"
+            ls -la
+            exit 1
+          fi
+          if ls ./tdlib/lib/libssl.a ./tdlib/lib/libcrypto.a ./tdlib/lib/libz.a >/dev/null 2>&1; then
+            ls -la ./tdlib/lib/libssl.a ./tdlib/lib/libcrypto.a ./tdlib/lib/libz.a
+            exit 0
+          fi
+          echo "Static archives missing from ./tdlib/lib; copying from cached td/tdlib/lib"
+          cp -f ./td/tdlib/lib/libssl.a ./tdlib/lib/
+          cp -f ./td/tdlib/lib/libcrypto.a ./tdlib/lib/
+          cp -f ./td/tdlib/lib/libz.a ./tdlib/lib/
+          ls -la ./tdlib/lib || true
+
       - name: Fix TDLib permissions (files + directories)
         if: contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download'
         run: |

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -93,9 +93,28 @@ jobs:
       - name: Copy static TDLib archives for local-tdlib,static
         if: matrix.feature == 'local-tdlib,static'
         run: |
-          OPENSSL_SSL="$(find /opt/homebrew /usr/local -maxdepth 6 -type f -name 'libssl.a' 2>/dev/null | head -n 1)"
-          OPENSSL_CRYPTO="$(find /opt/homebrew /usr/local -maxdepth 6 -type f -name 'libcrypto.a' 2>/dev/null | head -n 1)"
-          ZLIB_LIB="$(find /opt/homebrew /usr/local -maxdepth 6 -type f -name 'libz.a' 2>/dev/null | head -n 1)"
+          OPENSSL_PREFIX="$(brew --prefix openssl@3 2>/dev/null || brew --prefix openssl 2>/dev/null || brew --prefix openssl@1.1 2>/dev/null || true)"
+          ZLIB_PREFIX="$(brew --prefix zlib 2>/dev/null || true)"
+
+          OPENSSL_SSL=""
+          OPENSSL_CRYPTO=""
+          if [ -n "$OPENSSL_PREFIX" ]; then
+            OPENSSL_SSL="$OPENSSL_PREFIX/lib/libssl.a"
+            OPENSSL_CRYPTO="$OPENSSL_PREFIX/lib/libcrypto.a"
+          fi
+
+          ZLIB_LIB=""
+          if [ -n "$ZLIB_PREFIX" ]; then
+            ZLIB_LIB="$ZLIB_PREFIX/lib/libz.a"
+          fi
+
+          if [ ! -f "$OPENSSL_SSL" ] || [ ! -f "$OPENSSL_CRYPTO" ]; then
+            OPENSSL_SSL="$(find /opt/homebrew /usr/local -maxdepth 10 -type f -name 'libssl.a' 2>/dev/null | head -n 1)"
+            OPENSSL_CRYPTO="$(find /opt/homebrew /usr/local -maxdepth 10 -type f -name 'libcrypto.a' 2>/dev/null | head -n 1)"
+          fi
+          if [ ! -f "$ZLIB_LIB" ]; then
+            ZLIB_LIB="$(find /opt/homebrew /usr/local -maxdepth 10 -type f -name 'libz.a' 2>/dev/null | head -n 1)"
+          fi
           if [ -z "$OPENSSL_SSL" ] || [ -z "$OPENSSL_CRYPTO" ]; then
             echo "OpenSSL static libs not found"
             find /opt/homebrew /usr/local -type f \( -name 'libssl.a' -o -name 'libcrypto.a' \) | head -n 20
@@ -116,10 +135,36 @@ jobs:
               exit 1
             fi
           fi
+          # Put archives into the TDLib prefix that LOCAL_TDLIB_PATH points to (copied later as ./tdlib),
+          # and also into the cached build tree (./td/tdlib) so the cache stays self-contained.
           mkdir -p ./td/tdlib/lib
           cp -f "$OPENSSL_SSL" "./td/tdlib/lib/"
           cp -f "$OPENSSL_CRYPTO" "./td/tdlib/lib/"
           cp -f "$ZLIB_LIB" "./td/tdlib/lib/"
+          if [ -d "./tdlib/lib" ]; then
+            cp -f "$OPENSSL_SSL" "./tdlib/lib/" || true
+            cp -f "$OPENSSL_CRYPTO" "./tdlib/lib/" || true
+            cp -f "$ZLIB_LIB" "./tdlib/lib/" || true
+          fi
+
+      - name: Ensure OpenSSL/zlib static archives exist in LOCAL_TDLIB_PATH
+        if: matrix.feature == 'local-tdlib,static'
+        run: |
+          # This runs after Extract TDLib and before cargo build, so LOCAL_TDLIB_PATH has the archives.
+          if [ ! -d "./tdlib/lib" ]; then
+            echo "tdlib/lib not found; did Extract TDLib run?"
+            ls -la
+            exit 1
+          fi
+          if ls ./tdlib/lib/libssl.a ./tdlib/lib/libcrypto.a ./tdlib/lib/libz.a >/dev/null 2>&1; then
+            ls -la ./tdlib/lib/libssl.a ./tdlib/lib/libcrypto.a ./tdlib/lib/libz.a
+            exit 0
+          fi
+          echo "Static archives missing from ./tdlib/lib; copying from cached td/tdlib/lib"
+          cp -f ./td/tdlib/lib/libssl.a ./tdlib/lib/ || true
+          cp -f ./td/tdlib/lib/libcrypto.a ./tdlib/lib/ || true
+          cp -f ./td/tdlib/lib/libz.a ./tdlib/lib/ || true
+          ls -la ./tdlib/lib || true
 
       - name: Save cache TDLib
         if: steps.cache-tdlib-restore.outputs.cache-hit != 'true' && (contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download')

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         # os: [macos-13, macos-14]
         os: [macos-15-intel, macos-14]
-        feature: [local-tdlib, download-tdlib, pkg-config, "local-tdlib,static", "download-tdlib,static"]
+        feature: [local-tdlib, download-tdlib, static-download, pkg-config, "local-tdlib,static"]
 
     runs-on: ${{ matrix.os }}
 
@@ -49,14 +49,14 @@ jobs:
         run: brew install chafa
 
       - name: Restore cache TDLib
-        if: contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib')
+        if: contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download'
         id: cache-tdlib-restore
         uses: actions/cache/restore@v5
         with:
           path: td/
           key: ${{ runner.os }}-${{ runner.arch }}-TDLib-${{ env.TDLIB_VERSION }}
       - name: Build TDLib
-        if: steps.cache-tdlib-restore.outputs.cache-hit != 'true' && (contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib'))
+        if: steps.cache-tdlib-restore.outputs.cache-hit != 'true' && (contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download')
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           brew install gperf openssl zlib
@@ -122,33 +122,33 @@ jobs:
           cp -f "$ZLIB_LIB" "./td/tdlib/lib/"
 
       - name: Save cache TDLib
-        if: steps.cache-tdlib-restore.outputs.cache-hit != 'true' && (contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib'))
+        if: steps.cache-tdlib-restore.outputs.cache-hit != 'true' && (contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download')
         uses: actions/cache/save@v5
         with:
           path: td/
           key: ${{ steps.cache-tdlib-restore.outputs.cache-primary-key }}
 
       - name: Extract TDLib x86_64
-        if: runner.arch == 'x64' && (contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib'))
+        if: runner.arch == 'x64' && (contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download')
         run: |
           cp -r ./td/tdlib ./
           # cp ./tdlib/lib/libtdjson.*.dylib /usr/local/lib/
 
       - name: Extract TDLib ARM64
-        if: runner.arch == 'ARM64' && (contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib'))
+        if: runner.arch == 'ARM64' && (contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download')
         run: |
           cp -r ./td/tdlib ./
           # sudo cp ./tdlib/lib/libtdjson.*.dylib /usr/local/lib/
        
       - name: Fix TDLib permissions (files + directories)
-        if: contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib')
+        if: contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download'
         run: |
           sudo chown -R "$(id -u):$(id -g)" tdlib
           chmod -R u+rwX tdlib
 
       # Install dylib into /usr/local/lib so build script (and dyld) can find it at runtime
       - name: Install TDLib dylib to /usr/local/lib (macOS)
-        if: contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib')
+        if: contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download'
         run: |
           sudo mkdir -p /usr/local/lib
           sudo cp -f tdlib/lib/libtdjson.*.dylib /usr/local/lib/
@@ -169,7 +169,7 @@ jobs:
 
       # dyld looks in target/debug/deps first; put dylib there so build script finds it (macOS ignores DYLD_LIBRARY_PATH in some contexts). For download-tdlib we bootstrap with our TDLib build so the build script can run; it then downloads its own copy for the app.
       - name: Place TDLib dylib in target/debug/deps (macOS)
-        if: contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib')
+        if: contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download'
         run: |
           mkdir -p target/debug/deps
           cp -f tdlib/lib/libtdjson.*.dylib target/debug/deps/

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -174,15 +174,58 @@ jobs:
             ls -la
             exit 1
           fi
-          if ls ./tdlib/lib/libssl.a ./tdlib/lib/libcrypto.a ./tdlib/lib/libz.a >/dev/null 2>&1; then
-            ls -la ./tdlib/lib/libssl.a ./tdlib/lib/libcrypto.a ./tdlib/lib/libz.a
-            exit 0
+          # Prefer copying from Homebrew prefixes; caches may not include these.
+          OPENSSL_PREFIX="$(brew --prefix openssl@3 2>/dev/null || brew --prefix openssl 2>/dev/null || brew --prefix openssl@1.1 2>/dev/null || true)"
+          ZLIB_PREFIX="$(brew --prefix zlib 2>/dev/null || true)"
+
+          if [ -n "$OPENSSL_PREFIX" ]; then
+            if [ -f "$OPENSSL_PREFIX/lib/libssl.a" ]; then
+              cp -f "$OPENSSL_PREFIX/lib/libssl.a" ./tdlib/lib/
+            fi
+            if [ -f "$OPENSSL_PREFIX/lib/libcrypto.a" ]; then
+              cp -f "$OPENSSL_PREFIX/lib/libcrypto.a" ./tdlib/lib/
+            fi
           fi
-          echo "Static archives missing from ./tdlib/lib; copying from cached td/tdlib/lib"
-          cp -f ./td/tdlib/lib/libssl.a ./tdlib/lib/
-          cp -f ./td/tdlib/lib/libcrypto.a ./tdlib/lib/
-          cp -f ./td/tdlib/lib/libz.a ./tdlib/lib/
+
+          if [ -n "$ZLIB_PREFIX" ] && [ -f "$ZLIB_PREFIX/lib/libz.a" ]; then
+            cp -f "$ZLIB_PREFIX/lib/libz.a" ./tdlib/lib/
+          fi
+
+          # Fallback: search common prefixes.
+          if [ ! -f ./tdlib/lib/libssl.a ] || [ ! -f ./tdlib/lib/libcrypto.a ]; then
+            SSL_FALLBACK="$(find /opt/homebrew /usr/local -maxdepth 10 -type f -name 'libssl.a' 2>/dev/null | head -n 1 || true)"
+            CRYPTO_FALLBACK="$(find /opt/homebrew /usr/local -maxdepth 10 -type f -name 'libcrypto.a' 2>/dev/null | head -n 1 || true)"
+            if [ -n "$SSL_FALLBACK" ]; then cp -f "$SSL_FALLBACK" ./tdlib/lib/; fi
+            if [ -n "$CRYPTO_FALLBACK" ]; then cp -f "$CRYPTO_FALLBACK" ./tdlib/lib/; fi
+          fi
+
+          if [ ! -f ./tdlib/lib/libz.a ]; then
+            Z_FALLBACK="$(find /opt/homebrew /usr/local -maxdepth 10 -type f -name 'libz.a' 2>/dev/null | head -n 1 || true)"
+            if [ -n "$Z_FALLBACK" ]; then
+              cp -f "$Z_FALLBACK" ./tdlib/lib/
+            else
+              echo "libz.a not found; building zlib from source"
+              ZLIB_BUILD_DIR="$(mktemp -d)"
+              trap 'rm -rf "$ZLIB_BUILD_DIR"' EXIT
+              curl -L https://zlib.net/zlib-1.3.2.tar.gz | tar -xzf - -C "$ZLIB_BUILD_DIR"
+              cd "$ZLIB_BUILD_DIR"/zlib-1.3.2
+              ./configure --static --prefix="$ZLIB_BUILD_DIR/install"
+              make -j"$(sysctl -n hw.ncpu)"
+              make install
+              cp -f "$ZLIB_BUILD_DIR/install/lib/libz.a" "$GITHUB_WORKSPACE/tdlib/lib/"
+            fi
+          fi
+
+          echo "--- tdlib/lib after ensuring static archives ---"
           ls -la ./tdlib/lib || true
+
+          if [ ! -f ./tdlib/lib/libssl.a ] || [ ! -f ./tdlib/lib/libcrypto.a ] || [ ! -f ./tdlib/lib/libz.a ]; then
+            echo "Missing required static archives in ./tdlib/lib"
+            echo "libssl.a:   $(test -f ./tdlib/lib/libssl.a && echo OK || echo MISSING)"
+            echo "libcrypto.a:$(test -f ./tdlib/lib/libcrypto.a && echo OK || echo MISSING)"
+            echo "libz.a:     $(test -f ./tdlib/lib/libz.a && echo OK || echo MISSING)"
+            exit 1
+          fi
 
       - name: Fix TDLib permissions (files + directories)
         if: contains(matrix.feature, 'local-tdlib') || contains(matrix.feature, 'pkg-config') || contains(matrix.feature, 'download-tdlib') || matrix.feature == 'static-download'

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, windows-11-arm]
-        feature: [local-tdlib, pkg-config, download-tdlib, "local-tdlib,static", "download-tdlib,static"]
+        feature: [local-tdlib, pkg-config, download-tdlib, static-download, "local-tdlib,static"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -139,12 +139,21 @@ jobs:
             TRIPLET=arm64-windows-static
           fi
           mkdir -p ./tdlib/lib
-          for lib in libssl.a libcrypto.a libz.a ssl.lib crypto.lib zlib.lib; do
+          # tdlib-rs expects libssl.lib + libcrypto.lib + zlib.lib on Windows when `static` is enabled.
+          for lib in libssl.lib libcrypto.lib zlib.lib ssl.lib crypto.lib; do
             path=$(find ./td/vcpkg/installed/$TRIPLET -type f -name "$lib" 2>/dev/null | head -n 1 || true)
             if [ -n "$path" ]; then
               cp -f "$path" ./tdlib/lib/
             fi
           done
+          # Some toolchains provide ssl.lib/crypto.lib; create the names tdlib-rs looks for.
+          if [ -f ./tdlib/lib/ssl.lib ] && [ ! -f ./tdlib/lib/libssl.lib ]; then
+            cp -f ./tdlib/lib/ssl.lib ./tdlib/lib/libssl.lib
+          fi
+          if [ -f ./tdlib/lib/crypto.lib ] && [ ! -f ./tdlib/lib/libcrypto.lib ]; then
+            cp -f ./tdlib/lib/crypto.lib ./tdlib/lib/libcrypto.lib
+          fi
+          ls -la ./tdlib/lib || true
         shell: bash
 
       - name: Install pkg-config

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -153,7 +153,17 @@ jobs:
           if [ -f ./tdlib/lib/crypto.lib ] && [ ! -f ./tdlib/lib/libcrypto.lib ]; then
             cp -f ./tdlib/lib/crypto.lib ./tdlib/lib/libcrypto.lib
           fi
+          echo "--- tdlib/lib contents ---"
           ls -la ./tdlib/lib || true
+          echo "--- required files ---"
+          for f in ./tdlib/lib/libssl.lib ./tdlib/lib/libcrypto.lib ./tdlib/lib/zlib.lib; do
+            if [ ! -f "$f" ]; then
+              echo "Missing required static lib: $f"
+              echo "vcpkg search locations:"
+              find ./td/vcpkg/installed/$TRIPLET -maxdepth 5 -type f \( -name 'libssl.lib' -o -name 'libcrypto.lib' -o -name 'zlib.lib' -o -name 'ssl.lib' -o -name 'crypto.lib' \) 2>/dev/null | head -n 50 || true
+              exit 1
+            fi
+          done
         shell: bash
 
       - name: Install pkg-config
@@ -189,7 +199,11 @@ jobs:
 
       - name: Set LOCAL_TDLIB_PATH
         if: contains(matrix.feature, 'local-tdlib')
-        run: echo "LOCAL_TDLIB_PATH=$((Get-Item .).FullName)\tdlib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        run: |
+          $root = (Get-Item .).FullName
+          $tdlib = Join-Path $root "tdlib"
+          echo "LOCAL_TDLIB_PATH=$tdlib" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: pwsh
       # - name: Cache cargo
       #   uses: actions/cache@v4
       #   with:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -140,8 +140,9 @@ jobs:
           fi
           mkdir -p ./tdlib/lib
           # tdlib-rs expects libssl.lib + libcrypto.lib + zlib.lib on Windows when `static` is enabled.
-          for lib in libssl.lib libcrypto.lib zlib.lib ssl.lib crypto.lib; do
-            path=$(find ./td/vcpkg/installed/$TRIPLET -type f -name "$lib" 2>/dev/null | head -n 1 || true)
+          # vcpkg sometimes uses alternate names like libssl_static.lib or zlibstatic.lib.
+          for lib in libssl.lib libcrypto.lib zlib.lib libssl_static.lib libcrypto_static.lib zlibstatic.lib ssl.lib crypto.lib; do
+            path=$(find ./td/vcpkg/installed/$TRIPLET -maxdepth 20 -type f -name "$lib" 2>/dev/null | head -n 1 || true)
             if [ -n "$path" ]; then
               cp -f "$path" ./tdlib/lib/
             fi
@@ -153,6 +154,10 @@ jobs:
           if [ -f ./tdlib/lib/crypto.lib ] && [ ! -f ./tdlib/lib/libcrypto.lib ]; then
             cp -f ./tdlib/lib/crypto.lib ./tdlib/lib/libcrypto.lib
           fi
+          # zlib may be shipped as zlibstatic.lib; duplicate it to zlib.lib for tdlib-rs.
+          if [ -f ./tdlib/lib/zlibstatic.lib ] && [ ! -f ./tdlib/lib/zlib.lib ]; then
+            cp -f ./tdlib/lib/zlibstatic.lib ./tdlib/lib/zlib.lib
+          fi
           echo "--- tdlib/lib contents ---"
           ls -la ./tdlib/lib || true
           echo "--- required files ---"
@@ -160,7 +165,7 @@ jobs:
             if [ ! -f "$f" ]; then
               echo "Missing required static lib: $f"
               echo "vcpkg search locations:"
-              find ./td/vcpkg/installed/$TRIPLET -maxdepth 5 -type f \( -name 'libssl.lib' -o -name 'libcrypto.lib' -o -name 'zlib.lib' -o -name 'ssl.lib' -o -name 'crypto.lib' \) 2>/dev/null | head -n 50 || true
+              find ./td/vcpkg/installed/$TRIPLET -maxdepth 20 -type f \( -name 'libssl.lib' -o -name 'libcrypto.lib' -o -name 'zlib.lib' -o -name 'libssl_static.lib' -o -name 'libcrypto_static.lib' -o -name 'zlibstatic.lib' -o -name 'ssl.lib' -o -name 'crypto.lib' \) 2>/dev/null | head -n 200 || true
               exit 1
             fi
           done

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -147,6 +147,16 @@ jobs:
               cp -f "$path" ./tdlib/lib/
             fi
           done
+          # Last-resort fallback: search any installed triplet for these libs (helps when triplet naming differs).
+          if [ ! -f ./tdlib/lib/libssl.lib ] || [ ! -f ./tdlib/lib/libcrypto.lib ] || [ ! -f ./tdlib/lib/zlib.lib ]; then
+            echo "Required libs not found in $TRIPLET; searching all vcpkg installed triplets..."
+            for lib in libssl.lib libcrypto.lib zlib.lib libssl_static.lib libcrypto_static.lib zlibstatic.lib ssl.lib crypto.lib; do
+              path=$(find ./td/vcpkg/installed -maxdepth 40 -type f -name "$lib" 2>/dev/null | head -n 1 || true)
+              if [ -n "$path" ]; then
+                cp -f "$path" ./tdlib/lib/ || true
+              fi
+            done
+          fi
           # Some toolchains provide ssl.lib/crypto.lib; create the names tdlib-rs looks for.
           if [ -f ./tdlib/lib/ssl.lib ] && [ ! -f ./tdlib/lib/libssl.lib ]; then
             cp -f ./tdlib/lib/ssl.lib ./tdlib/lib/libssl.lib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ arboard = { version = "3.6.1", features = ["wayland-data-control", "wl-clipboard
 dirs = "6.0.0"
 reqwest = { version = "0.13.2", features = ["blocking"] }
 zip = { version = "8.5.1" }
-tdlib-rs = "1.4.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ local-tdlib = ["tdlib-rs/local-tdlib"]
 download-tdlib = ["tdlib-rs/download-tdlib"]
 pkg-config = ["tdlib-rs/pkg-config"]
 static = ["tdlib-rs/static"]
+# Convenience feature: static linking + auto-download/build TDLib.
+static-download = ["static", "download-tdlib"]
 # Enable chafa-based image rendering in ratatui-image (macOS, Linux x86_64, Windows x64). Not supported on Windows ARM.
 chafa-dyn = ["ratatui-image/chafa-dyn"]
 chafa-static = ["ratatui-image/chafa-static"]
@@ -85,7 +87,7 @@ arboard = { version = "3.6.1", features = ["wayland-data-control", "wl-clipboard
 dirs = "6.0.0"
 reqwest = { version = "0.13.2", features = ["blocking"] }
 zip = { version = "8.5.1" }
-tdlib-rs = "1.3.0"
+tdlib-rs = "1.4.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ arboard = { version = "3.6.1", features = ["wayland-data-control", "wl-clipboard
 dirs = "6.0.0"
 reqwest = { version = "0.13.2", features = ["blocking"] }
 zip = { version = "8.5.1" }
+tdlib-rs = "1.4.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/build.rs
+++ b/build.rs
@@ -55,19 +55,6 @@ fn copy_default_config_into(config_dest: &std::path::Path, manifest_dir: &str) {
     }
 }
 
-fn build_tdlib_if_native(lib_path: Option<String>) {
-    let host = std::env::var("HOST").unwrap_or_default();
-    let target = std::env::var("TARGET").unwrap_or_default();
-    if host != target {
-        println!(
-            "cargo:warning=Cross-compiling from {host} to {target}; skipping tdlib-rs build helper in build script."
-        );
-        return;
-    }
-
-    tdlib_rs::build::build(lib_path);
-}
-
 fn main() -> std::io::Result<()> {
     // chafa-dyn and chafa-static are not supported on Windows ARM; fail the build if enabled there
     let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
@@ -84,7 +71,6 @@ fn main() -> std::io::Result<()> {
     }
 
     if cfg!(debug_assertions) {
-        build_tdlib_if_native(None);
         return Ok(());
     }
 
@@ -105,7 +91,6 @@ fn main() -> std::io::Result<()> {
 
     let (_, tdlib_dest) = tgt_build_paths();
     std::fs::create_dir_all(&tdlib_dest).unwrap();
-    build_tdlib_if_native(Some(tdlib_dest.to_string_lossy().into_owned()));
 
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -55,6 +55,19 @@ fn copy_default_config_into(config_dest: &std::path::Path, manifest_dir: &str) {
     }
 }
 
+fn build_tdlib_if_native(lib_path: Option<String>) {
+    let host = std::env::var("HOST").unwrap_or_default();
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if host != target {
+        println!(
+            "cargo:warning=Cross-compiling from {host} to {target}; skipping tdlib-rs build helper in build script."
+        );
+        return;
+    }
+
+    tdlib_rs::build::build(lib_path);
+}
+
 fn main() -> std::io::Result<()> {
     // chafa-dyn and chafa-static are not supported on Windows ARM; fail the build if enabled there
     let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
@@ -71,6 +84,7 @@ fn main() -> std::io::Result<()> {
     }
 
     if cfg!(debug_assertions) {
+        build_tdlib_if_native(None);
         return Ok(());
     }
 
@@ -91,6 +105,8 @@ fn main() -> std::io::Result<()> {
 
     let (_, tdlib_dest) = tgt_build_paths();
     std::fs::create_dir_all(&tdlib_dest).unwrap();
+
+    build_tdlib_if_native(Some(tdlib_dest.to_string_lossy().into_owned()));
 
     Ok(())
 }

--- a/src/components/chat_list_window.rs
+++ b/src/components/chat_list_window.rs
@@ -578,39 +578,37 @@ impl Component for ChatListWindow {
             Action::FocusComponent(ComponentName::ChatList) => {
                 self.rebuild_visible_chats();
             }
-            Action::Key(key_code, modifiers) => {
-                if self.search_mode {
-                    match key_code {
-                        KeyCode::Char(c)
-                            if !modifiers.control && !modifiers.alt && !modifiers.shift =>
-                        {
-                            self.handle_search_char(c);
-                        }
-                        KeyCode::Backspace => {
-                            self.handle_search_backspace();
-                        }
-                        KeyCode::Enter => {
-                            // Open selected chat and exit search mode
-                            self.confirm_selection();
-                            self.stop_search();
-                        }
-                        KeyCode::Esc => {
-                            self.stop_search();
-                        }
-                        KeyCode::Down => {
-                            // Allow arrow key navigation in search mode
-                            self.next();
-                        }
-                        KeyCode::Up => {
-                            // Allow arrow key navigation in search mode
-                            self.previous();
-                        }
-                        KeyCode::Tab => {
-                            // Allow tab navigation in search mode
-                            self.next();
-                        }
-                        _ => {}
+            Action::Key(key_code, modifiers) if self.search_mode => {
+                match key_code {
+                    KeyCode::Char(c)
+                        if !modifiers.control && !modifiers.alt && !modifiers.shift =>
+                    {
+                        self.handle_search_char(c);
                     }
+                    KeyCode::Backspace => {
+                        self.handle_search_backspace();
+                    }
+                    KeyCode::Enter => {
+                        // Open selected chat and exit search mode
+                        self.confirm_selection();
+                        self.stop_search();
+                    }
+                    KeyCode::Esc => {
+                        self.stop_search();
+                    }
+                    KeyCode::Down => {
+                        // Allow arrow key navigation in search mode
+                        self.next();
+                    }
+                    KeyCode::Up => {
+                        // Allow arrow key navigation in search mode
+                        self.previous();
+                    }
+                    KeyCode::Tab => {
+                        // Allow tab navigation in search mode
+                        self.next();
+                    }
+                    _ => {}
                 }
             }
             _ => {}

--- a/src/components/chat_window.rs
+++ b/src/components/chat_window.rs
@@ -465,40 +465,38 @@ impl Component for ChatWindow {
                 // Handled by CoreWindow: opens search overlay or focuses ChatList
             }
             Action::LoadPinnedMessages => {}
-            Action::Key(key_code, modifiers) => {
-                if self.focused {
-                    let has_message_pins = !self
-                        .app_context
-                        .tg_context()
-                        .open_chat_pinned_snapshot()
-                        .is_empty();
-                    match key_code {
-                        KeyCode::Char('r') if modifiers.alt => {
-                            // Alt+R: switch to ChatList search (handled by CoreWindow)
-                            if let Some(tx) = self.action_tx.as_ref() {
-                                let _ = tx.send(Action::ChatListSearch);
-                            }
+            Action::Key(key_code, modifiers) if self.focused => {
+                let has_message_pins = !self
+                    .app_context
+                    .tg_context()
+                    .open_chat_pinned_snapshot()
+                    .is_empty();
+                match key_code {
+                    KeyCode::Char('r') if modifiers.alt => {
+                        // Alt+R: switch to ChatList search (handled by CoreWindow)
+                        if let Some(tx) = self.action_tx.as_ref() {
+                            let _ = tx.send(Action::ChatListSearch);
                         }
-                        // Shift+Tab: open pinned popup when keymap misses modifier quirks.
-                        KeyCode::BackTab if has_message_pins => {
-                            if let Some(tx) = self.action_tx.as_ref() {
-                                let _ = tx.send(Action::ShowPinnedMessagesPopup);
-                            }
-                        }
-                        KeyCode::Tab if modifiers.shift && has_message_pins => {
-                            if let Some(tx) = self.action_tx.as_ref() {
-                                let _ = tx.send(Action::ShowPinnedMessagesPopup);
-                            }
-                        }
-                        KeyCode::Up => self.next(),
-                        KeyCode::Down => {
-                            self.previous();
-                        }
-                        KeyCode::Tab if !modifiers.shift => {
-                            self.next();
-                        }
-                        _ => {}
                     }
+                    // Shift+Tab: open pinned popup when keymap misses modifier quirks.
+                    KeyCode::BackTab if has_message_pins => {
+                        if let Some(tx) = self.action_tx.as_ref() {
+                            let _ = tx.send(Action::ShowPinnedMessagesPopup);
+                        }
+                    }
+                    KeyCode::Tab if modifiers.shift && has_message_pins => {
+                        if let Some(tx) = self.action_tx.as_ref() {
+                            let _ = tx.send(Action::ShowPinnedMessagesPopup);
+                        }
+                    }
+                    KeyCode::Up => self.next(),
+                    KeyCode::Down => {
+                        self.previous();
+                    }
+                    KeyCode::Tab if !modifiers.shift => {
+                        self.next();
+                    }
+                    _ => {}
                 }
             }
             _ => {}

--- a/src/components/command_guide.rs
+++ b/src/components/command_guide.rs
@@ -257,35 +257,31 @@ impl Component for CommandGuide {
             Action::HideCommandGuide => {
                 self.hide();
             }
-            Action::Key(key_code, _modifiers) => {
-                if self.visible {
-                    match key_code {
-                        crossterm::event::KeyCode::Up => {
-                            self.scroll_offset = self.scroll_offset.saturating_sub(1);
-                        }
-                        crossterm::event::KeyCode::Down => {
-                            let max_scroll =
-                                self.last_content_lines
-                                    .saturating_sub(self.last_inner_height as usize)
-                                    .min(u16::MAX as usize) as u16;
-                            self.scroll_offset = (self.scroll_offset + 1).min(max_scroll);
-                        }
-                        crossterm::event::KeyCode::PageUp => {
-                            let page = self.last_inner_height;
-                            self.scroll_offset = self.scroll_offset.saturating_sub(page);
-                        }
-                        crossterm::event::KeyCode::PageDown => {
-                            let max_scroll =
-                                self.last_content_lines
-                                    .saturating_sub(self.last_inner_height as usize)
-                                    .min(u16::MAX as usize) as u16;
-                            let page = self.last_inner_height;
-                            self.scroll_offset = (self.scroll_offset + page).min(max_scroll);
-                        }
-                        _ => {}
-                    }
+            Action::Key(key_code, _modifiers) if self.visible => match key_code {
+                crossterm::event::KeyCode::Up => {
+                    self.scroll_offset = self.scroll_offset.saturating_sub(1);
                 }
-            }
+                crossterm::event::KeyCode::Down => {
+                    let max_scroll = self
+                        .last_content_lines
+                        .saturating_sub(self.last_inner_height as usize)
+                        .min(u16::MAX as usize) as u16;
+                    self.scroll_offset = (self.scroll_offset + 1).min(max_scroll);
+                }
+                crossterm::event::KeyCode::PageUp => {
+                    let page = self.last_inner_height;
+                    self.scroll_offset = self.scroll_offset.saturating_sub(page);
+                }
+                crossterm::event::KeyCode::PageDown => {
+                    let max_scroll = self
+                        .last_content_lines
+                        .saturating_sub(self.last_inner_height as usize)
+                        .min(u16::MAX as usize) as u16;
+                    let page = self.last_inner_height;
+                    self.scroll_offset = (self.scroll_offset + page).min(max_scroll);
+                }
+                _ => {}
+            },
             _ => {}
         }
     }

--- a/src/components/file_download_explorer.rs
+++ b/src/components/file_download_explorer.rs
@@ -171,22 +171,18 @@ impl FileDownloadExplorer {
                     let _ = tx.send(Action::HideFileDownloadExplorer);
                 }
             }
-            KeyCode::Enter => {
-                if self.sanitized_filename().is_some() {
-                    self.phase = DownloadPhase::PickFolder;
-                    self.explorer
-                        .set_theme(Self::build_explorer_theme(Arc::clone(&self.app_context)));
-                    let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-                    let _ = self.explorer.set_cwd(home_dir);
-                }
+            KeyCode::Enter if self.sanitized_filename().is_some() => {
+                self.phase = DownloadPhase::PickFolder;
+                self.explorer
+                    .set_theme(Self::build_explorer_theme(Arc::clone(&self.app_context)));
+                let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+                let _ = self.explorer.set_cwd(home_dir);
             }
             KeyCode::Left if !modifiers.contains(KeyModifiers::ALT) => {
                 self.filename_cursor = self.filename_cursor.saturating_sub(1);
             }
-            KeyCode::Right => {
-                if self.filename_cursor < self.filename_chars.len() {
-                    self.filename_cursor += 1;
-                }
+            KeyCode::Right if self.filename_cursor < self.filename_chars.len() => {
+                self.filename_cursor += 1;
             }
             KeyCode::Home => {
                 self.filename_cursor = 0;
@@ -194,22 +190,16 @@ impl FileDownloadExplorer {
             KeyCode::End => {
                 self.filename_cursor = self.filename_chars.len();
             }
-            KeyCode::Backspace => {
-                if self.filename_cursor > 0 {
-                    self.filename_cursor -= 1;
-                    self.filename_chars.remove(self.filename_cursor);
-                }
+            KeyCode::Backspace if self.filename_cursor > 0 => {
+                self.filename_cursor -= 1;
+                self.filename_chars.remove(self.filename_cursor);
             }
-            KeyCode::Delete => {
-                if self.filename_cursor < self.filename_chars.len() {
-                    self.filename_chars.remove(self.filename_cursor);
-                }
+            KeyCode::Delete if self.filename_cursor < self.filename_chars.len() => {
+                self.filename_chars.remove(self.filename_cursor);
             }
-            KeyCode::Char(c) if !modifiers.contains(KeyModifiers::CONTROL) => {
-                if !c.is_control() {
-                    self.filename_chars.insert(self.filename_cursor, c);
-                    self.filename_cursor += 1;
-                }
+            KeyCode::Char(c) if !modifiers.contains(KeyModifiers::CONTROL) && !c.is_control() => {
+                self.filename_chars.insert(self.filename_cursor, c);
+                self.filename_cursor += 1;
             }
             _ => {}
         }

--- a/src/components/photo_viewer.rs
+++ b/src/components/photo_viewer.rs
@@ -217,17 +217,16 @@ impl Component for PhotoViewer {
                 // These actions are handled by CoreWindow, which forwards them to ChatWindow
                 // No action needed here
             }
-            Action::Key(key_code, _modifiers) => {
-                if self.visible {
-                    match key_code {
-                        crossterm::event::KeyCode::Esc | crossterm::event::KeyCode::Char('q') => {
-                            self.hide();
-                            if let Some(tx) = self.action_tx.as_ref() {
-                                tx.send(Action::HidePhotoViewer).unwrap_or(());
-                            }
-                        }
-                        _ => {}
-                    }
+            Action::Key(crossterm::event::KeyCode::Esc, _modifiers) if self.visible => {
+                self.hide();
+                if let Some(tx) = self.action_tx.as_ref() {
+                    tx.send(Action::HidePhotoViewer).unwrap_or(());
+                }
+            }
+            Action::Key(crossterm::event::KeyCode::Char('q'), _modifiers) if self.visible => {
+                self.hide();
+                if let Some(tx) = self.action_tx.as_ref() {
+                    tx.send(Action::HidePhotoViewer).unwrap_or(());
                 }
             }
             _ => {}

--- a/src/components/pinned_messages_popup.rs
+++ b/src/components/pinned_messages_popup.rs
@@ -123,10 +123,8 @@ impl Component for PinnedMessagesPopup {
                     let _ = tx.send(Action::PlayVoiceMessage(id));
                 }
             }
-            Action::LoadPinnedMessages => {
-                if self.visible {
-                    self.reload_from_context();
-                }
+            Action::LoadPinnedMessages if self.visible => {
+                self.reload_from_context();
             }
             _ => {}
         }

--- a/src/components/theme_selector.rs
+++ b/src/components/theme_selector.rs
@@ -190,24 +190,22 @@ impl Component for ThemeSelector {
             Action::HideThemeSelector => {
                 self.hide();
             }
-            Action::Key(key_code, _modifiers) => {
-                if self.visible {
-                    match key_code {
-                        crossterm::event::KeyCode::Up => {
-                            self.select_previous();
-                        }
-                        crossterm::event::KeyCode::Down => {
-                            self.select_next();
-                        }
-                        crossterm::event::KeyCode::Enter => {
-                            // Apply current selection and close
-                            self.hide();
-                            if let Some(tx) = self.action_tx.as_ref() {
-                                tx.send(Action::HideThemeSelector).unwrap_or(());
-                            }
-                        }
-                        _ => {}
+            Action::Key(key_code, _modifiers) if self.visible => {
+                match key_code {
+                    crossterm::event::KeyCode::Up => {
+                        self.select_previous();
                     }
+                    crossterm::event::KeyCode::Down => {
+                        self.select_next();
+                    }
+                    crossterm::event::KeyCode::Enter => {
+                        // Apply current selection and close
+                        self.hide();
+                        if let Some(tx) = self.action_tx.as_ref() {
+                            tx.send(Action::HideThemeSelector).unwrap_or(());
+                        }
+                    }
+                    _ => {}
                 }
             }
             _ => {}

--- a/src/run.rs
+++ b/src/run.rs
@@ -280,6 +280,45 @@ async fn consume_until_single_action(
         }
     }
 }
+
+/// TDLib can emit long bursts of chat-list-related updates. The main loop would otherwise drain
+/// thousands of [`Action::ChatHistoryAppended`] / [`Action::Refresh`] in one turn, each forcing
+/// chat list work. Compress any run consisting only of those two variants to at most one refresh
+/// tick plus one list sync (order preserved relative to other actions).
+fn fold_chat_list_refresh_actions(actions: Vec<Action>) -> Vec<Action> {
+    if actions.is_empty() {
+        return actions;
+    }
+    let mut out = Vec::with_capacity(actions.len());
+    let mut i = 0;
+    while i < actions.len() {
+        if matches!(actions[i], Action::ChatHistoryAppended | Action::Refresh) {
+            let mut saw_refresh = false;
+            let mut saw_cha = false;
+            while i < actions.len()
+                && matches!(actions[i], Action::ChatHistoryAppended | Action::Refresh)
+            {
+                match &actions[i] {
+                    Action::Refresh => saw_refresh = true,
+                    Action::ChatHistoryAppended => saw_cha = true,
+                    _ => {}
+                }
+                i += 1;
+            }
+            if saw_refresh {
+                out.push(Action::Refresh);
+            }
+            if saw_cha {
+                out.push(Action::ChatHistoryAppended);
+            }
+        } else {
+            out.push(actions[i].clone());
+            i += 1;
+        }
+    }
+    out
+}
+
 /// Returns true for actions that change UI-visible state and should trigger a render.
 fn action_changes_ui(action: &Action) -> bool {
     matches!(
@@ -349,8 +388,13 @@ fn action_changes_ui(action: &Action) -> bool {
     )
 }
 
-#[allow(clippy::await_holding_lock)]
 /// Handle incoming actions from the application.
+///
+/// Bursts of [`Action::ChatHistoryAppended`] / [`Action::Refresh`] are folded before handling
+/// ([`fold_chat_list_refresh_actions`]) so one TDLib flurry does not run thousands of chat-list
+/// rebuilds in a single turn. [`crate::tg::tg_context::TgContext`] mutexes are not held across
+/// `.await` in the [`Action::GetChatHistory`] path (loads use discrete lock regions per batch).
+#[allow(clippy::await_holding_lock)]
 ///
 /// # Arguments
 /// * `app_context` - An Arc wrapped AppContext struct.
@@ -366,7 +410,27 @@ pub async fn handle_app_actions(
     tui_backend: &mut TuiBackend,
     tg_backend: &mut TgBackend,
 ) -> Result<(), AppError<Action>> {
-    while let Ok(action) = app_context.action_rx().try_recv() {
+    let mut batch = Vec::new();
+    while let Ok(a) = app_context.action_rx().try_recv() {
+        batch.push(a);
+    }
+    if batch.is_empty() {
+        return Ok(());
+    }
+
+    let raw_len = batch.len();
+    let folded = fold_chat_list_refresh_actions(batch);
+    let folded_len = folded.len();
+    if raw_len > 64 {
+        tracing::debug!(
+            target: "tgt::actions",
+            raw = raw_len,
+            folded = folded_len,
+            "folded action batch (TDLib/UI burst)"
+        );
+    }
+
+    for action in folded {
         match &action {
             Action::Render => {
                 // Actual draw happens at end of loop when should_render()
@@ -907,6 +971,10 @@ pub async fn handle_app_actions(
         tui.update(action.clone())
     }
 
+    if raw_len >= 32 {
+        tokio::task::yield_now().await;
+    }
+
     if app_context.should_render() {
         tui_backend.terminal.draw(|f| {
             tui.draw(f, f.area()).unwrap();
@@ -1049,4 +1117,39 @@ async fn log_out(tg_backend: &mut TgBackend) {
 
     // Clear the terminal and move the cursor to the top left corner
     io::Write::write_all(&mut io::stdout().lock(), b"\x1b[2J\x1b[1;1H").unwrap();
+}
+
+#[cfg(test)]
+mod fold_action_tests {
+    use super::{fold_chat_list_refresh_actions, Action};
+
+    #[test]
+    fn fold_compresses_long_cha_refresh_run() {
+        let v = vec![
+            Action::ChatHistoryAppended,
+            Action::ChatHistoryAppended,
+            Action::Refresh,
+            Action::ChatHistoryAppended,
+        ];
+        let f = fold_chat_list_refresh_actions(v);
+        assert_eq!(f.len(), 2);
+        assert!(matches!(f[0], Action::Refresh));
+        assert!(matches!(f[1], Action::ChatHistoryAppended));
+    }
+
+    #[test]
+    fn fold_preserves_other_actions_in_order() {
+        let v = vec![
+            Action::ChatHistoryAppended,
+            Action::Quit,
+            Action::Refresh,
+            Action::ChatHistoryAppended,
+        ];
+        let f = fold_chat_list_refresh_actions(v);
+        assert_eq!(f.len(), 4);
+        assert!(matches!(f[0], Action::ChatHistoryAppended));
+        assert!(matches!(f[1], Action::Quit));
+        assert!(matches!(f[2], Action::Refresh));
+        assert!(matches!(f[3], Action::ChatHistoryAppended));
+    }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -531,45 +531,42 @@ pub async fn handle_app_actions(
                     }
                 }
             }
-            Action::GetChatHistory => {
-                if !app_context.tg_context().is_history_loading() {
-                    app_context.tg_context().set_history_loading(true);
-                    let chat_id = app_context.tg_context().open_chat_id().as_i64();
-                    let cache_len_before = app_context.tg_context().open_chat_messages().len();
+            Action::GetChatHistory if !app_context.tg_context().is_history_loading() => {
+                app_context.tg_context().set_history_loading(true);
+                let chat_id = app_context.tg_context().open_chat_id().as_i64();
+                let cache_len_before = app_context.tg_context().open_chat_messages().len();
 
-                    // If cache is empty (initial load), load 100 messages to fill the window
-                    // Otherwise, load just ONE batch (50 messages) for incremental scrolling
-                    let target_load = if cache_len_before == 0 { 100 } else { 50 };
-                    let mut loaded_count = 0;
+                // If cache is empty (initial load), load 100 messages to fill the window
+                // Otherwise, load just ONE batch (50 messages) for incremental scrolling
+                let target_load = if cache_len_before == 0 { 100 } else { 50 };
+                let mut loaded_count = 0;
 
-                    while loaded_count < target_load {
-                        if app_context.tg_context().open_chat_id().as_i64() != chat_id {
-                            break;
-                        }
-
-                        // Always use the oldest message in cache (or 0 if empty) to ensure continuity
-                        let from_message_id =
-                            app_context.tg_context().oldest_message_id().unwrap_or(0);
-                        let (entries, _has_more) = tg_backend
-                            .get_chat_history_one_batch(chat_id, from_message_id)
-                            .await;
-
-                        if entries.is_empty() {
-                            break;
-                        }
-
-                        if app_context.tg_context().open_chat_id().as_i64() != chat_id {
-                            break;
-                        }
-
-                        let tg = app_context.tg_context();
-                        loaded_count += entries.len();
-                        tg.open_chat_messages().insert_messages(entries.clone());
+                while loaded_count < target_load {
+                    if app_context.tg_context().open_chat_id().as_i64() != chat_id {
+                        break;
                     }
 
-                    app_context.tg_context().set_history_loading(false);
-                    let _ = app_context.action_tx().send(Action::ChatHistoryAppended);
+                    // Always use the oldest message in cache (or 0 if empty) to ensure continuity
+                    let from_message_id = app_context.tg_context().oldest_message_id().unwrap_or(0);
+                    let (entries, _has_more) = tg_backend
+                        .get_chat_history_one_batch(chat_id, from_message_id)
+                        .await;
+
+                    if entries.is_empty() {
+                        break;
+                    }
+
+                    if app_context.tg_context().open_chat_id().as_i64() != chat_id {
+                        break;
+                    }
+
+                    let tg = app_context.tg_context();
+                    loaded_count += entries.len();
+                    tg.open_chat_messages().insert_messages(entries.clone());
                 }
+
+                app_context.tg_context().set_history_loading(false);
+                let _ = app_context.action_tx().send(Action::ChatHistoryAppended);
             }
             Action::LoadPinnedMessages => {
                 let chat_id = app_context.tg_context().open_chat_id().as_i64();
@@ -581,45 +578,38 @@ pub async fn handle_app_actions(
                     app_context.tg_context().set_open_chat_pinned(pins);
                 }
             }
-            Action::GetChatHistoryNewer => {
-                if !app_context.tg_context().is_history_loading() {
-                    let chat_id = app_context.tg_context().open_chat_id().as_i64();
-                    let newest = app_context
-                        .tg_context()
-                        .open_chat_messages()
-                        .newest_message_id();
-                    if let Some(from_id) = newest {
-                        app_context.tg_context().set_history_loading(true);
-                        // TDLib: offset -N = from_message_id + N newer messages; limit >= -offset
-                        // Use offset -49 to get from_id (which we already have) + 49 newer, then filter out from_id
-                        const NEWER_BATCH: i32 = 50;
-                        let (entries, _) = tg_backend
-                            .get_chat_history_batch(
-                                chat_id,
-                                from_id,
-                                -(NEWER_BATCH - 1),
-                                NEWER_BATCH,
-                            )
-                            .await;
-                        if app_context.tg_context().open_chat_id().as_i64() == chat_id
-                            && !entries.is_empty()
-                        {
-                            // Skip the first message if it's the boundary message we already have
-                            let new_messages = if entries.first().map(|e| e.id()) == Some(from_id) {
-                                &entries[1..]
-                            } else {
-                                &entries[..]
-                            };
-                            if !new_messages.is_empty() {
-                                app_context
-                                    .tg_context()
-                                    .open_chat_messages()
-                                    .insert_messages(new_messages.iter().cloned());
-                            }
+            Action::GetChatHistoryNewer if !app_context.tg_context().is_history_loading() => {
+                let chat_id = app_context.tg_context().open_chat_id().as_i64();
+                let newest = app_context
+                    .tg_context()
+                    .open_chat_messages()
+                    .newest_message_id();
+                if let Some(from_id) = newest {
+                    app_context.tg_context().set_history_loading(true);
+                    // TDLib: offset -N = from_message_id + N newer messages; limit >= -offset
+                    // Use offset -49 to get from_id (which we already have) + 49 newer, then filter out from_id
+                    const NEWER_BATCH: i32 = 50;
+                    let (entries, _) = tg_backend
+                        .get_chat_history_batch(chat_id, from_id, -(NEWER_BATCH - 1), NEWER_BATCH)
+                        .await;
+                    if app_context.tg_context().open_chat_id().as_i64() == chat_id
+                        && !entries.is_empty()
+                    {
+                        // Skip the first message if it's the boundary message we already have
+                        let new_messages = if entries.first().map(|e| e.id()) == Some(from_id) {
+                            &entries[1..]
+                        } else {
+                            &entries[..]
+                        };
+                        if !new_messages.is_empty() {
+                            app_context
+                                .tg_context()
+                                .open_chat_messages()
+                                .insert_messages(new_messages.iter().cloned());
                         }
-                        app_context.tg_context().set_history_loading(false);
-                        let _ = app_context.action_tx().send(Action::ChatHistoryAppended);
                     }
+                    app_context.tg_context().set_history_loading(false);
+                    let _ = app_context.action_tx().send(Action::ChatHistoryAppended);
                 }
             }
             Action::SearchChatMessages(ref query) => {

--- a/src/tg/tg_backend.rs
+++ b/src/tg/tg_backend.rs
@@ -1302,6 +1302,8 @@ impl TgBackend {
                                 needs_chat_list_update = false;
                             }
                         }
+                        // Let the runtime schedule other tasks (main loop, I/O) during TDLib bursts.
+                        tokio::task::yield_now().await;
                     }
                     None => {
                         // No updates available, sleep briefly to avoid busy-wait loop

--- a/src/tg/tg_backend.rs
+++ b/src/tg/tg_backend.rs
@@ -1207,77 +1207,73 @@ impl TgBackend {
                                 }
                             }
                             Update::MessageEdited(_) => {}
-                            Update::MessageContent(message) => {
+                            Update::MessageContent(message)
                                 // Only touch open_chat_messages when update is for the open chat.
-                                if tg_context.open_chat_id().as_i64() == message.chat_id {
-                                    if let Some(entry) = tg_context
-                                        .open_chat_messages()
-                                        .get_message_mut(message.message_id)
-                                    {
-                                        entry.set_message_content(&message.new_content);
-                                        entry.set_is_edited(true);
-                                    }
+                                if tg_context.open_chat_id().as_i64() == message.chat_id =>
+                            {
+                                if let Some(entry) = tg_context
+                                    .open_chat_messages()
+                                    .get_message_mut(message.message_id)
+                                {
+                                    entry.set_message_content(&message.new_content);
+                                    entry.set_is_edited(true);
                                 }
                             }
-                            Update::MessageIsPinned(pin) => {
-                                if tg_context.open_chat_id().as_i64() == pin.chat_id {
-                                    let _ = action_tx.send(Action::LoadPinnedMessages);
-                                    let _ = wake_tx.send(());
-                                }
+                            Update::MessageIsPinned(pin)
+                                if tg_context.open_chat_id().as_i64() == pin.chat_id =>
+                            {
+                                let _ = action_tx.send(Action::LoadPinnedMessages);
+                                let _ = wake_tx.send(());
                             }
-                            Update::DeleteMessages(update_delete_messages) => {
+                            Update::DeleteMessages(update_delete_messages)
                                 // Only touch open_chat_messages when update is for the open chat.
                                 if tg_context.open_chat_id().as_i64()
-                                    == update_delete_messages.chat_id
-                                {
-                                    // When from_cache is true, TDLib evicted messages from its local cache
-                                    // (e.g. GC/sync after ~60s). They were NOT deleted on the server.
-                                    // Do not remove from our UI; optionally re-fetch so user sees them again.
-                                    if update_delete_messages.from_cache {
-                                        tracing::info!(
+                                    == update_delete_messages.chat_id =>
+                            {
+                                // When from_cache is true, TDLib evicted messages from its local cache
+                                // (e.g. GC/sync after ~60s). They were NOT deleted on the server.
+                                // Do not remove from our UI; optionally re-fetch so user sees them again.
+                                if update_delete_messages.from_cache {
+                                    tracing::info!(
                                         chat_id = update_delete_messages.chat_id,
                                         count = update_delete_messages.message_ids.len(),
                                         "TDLib DeleteMessages from_cache=true: ignoring (cache eviction, not server delete); re-fetching history"
                                     );
-                                        let _ = action_tx.send(Action::GetChatHistory);
-                                        let _ = wake_tx.send(());
-                                        continue;
-                                    }
-                                    let ids = &update_delete_messages.message_ids;
-                                    let count = ids.len();
-                                    let sample_first: Vec<i64> =
-                                        ids.iter().take(5).copied().collect();
-                                    let sample_last: Vec<i64> =
-                                        ids.iter().rev().take(5).copied().collect();
-                                    let (min_id, max_id) =
-                                        ids.iter().fold((i64::MAX, i64::MIN), |(min, max), &id| {
-                                            (min.min(id), max.max(id))
-                                        });
-                                    tracing::info!(
-                                        chat_id = update_delete_messages.chat_id,
-                                        count,
-                                        sample_first = ?sample_first,
-                                        sample_last = ?sample_last,
-                                        min_id,
-                                        max_id,
-                                        "TDLib DeleteMessages: removed messages from open chat (server delete)"
-                                    );
-                                    let mut store = tg_context.open_chat_messages();
-                                    for id in ids {
-                                        store.remove_message(*id);
-                                    }
-                                    // Send rate-limited chat list rebuild to update chat list (last message may have changed)
-                                    let now = std::time::Instant::now();
-                                    if now.duration_since(last_chat_list_update).as_millis()
-                                        >= rate_limit_ms
-                                    {
-                                        let _ = action_tx.send(Action::ChatHistoryAppended);
-                                        let _ = wake_tx.send(());
-                                        last_chat_list_update = now;
-                                        needs_chat_list_update = false;
-                                    } else {
-                                        needs_chat_list_update = true;
-                                    }
+                                    let _ = action_tx.send(Action::GetChatHistory);
+                                    let _ = wake_tx.send(());
+                                    continue;
+                                }
+                                let ids = &update_delete_messages.message_ids;
+                                let count = ids.len();
+                                let sample_first: Vec<i64> = ids.iter().take(5).copied().collect();
+                                let sample_last: Vec<i64> = ids.iter().rev().take(5).copied().collect();
+                                let (min_id, max_id) =
+                                    ids.iter().fold((i64::MAX, i64::MIN), |(min, max), &id| {
+                                        (min.min(id), max.max(id))
+                                    });
+                                tracing::info!(
+                                    chat_id = update_delete_messages.chat_id,
+                                    count,
+                                    sample_first = ?sample_first,
+                                    sample_last = ?sample_last,
+                                    min_id,
+                                    max_id,
+                                    "TDLib DeleteMessages: removed messages from open chat (server delete)"
+                                );
+                                let mut store = tg_context.open_chat_messages();
+                                for id in ids {
+                                    store.remove_message(*id);
+                                }
+                                // Send rate-limited chat list rebuild to update chat list (last message may have changed)
+                                let now = std::time::Instant::now();
+                                if now.duration_since(last_chat_list_update).as_millis() >= rate_limit_ms
+                                {
+                                    let _ = action_tx.send(Action::ChatHistoryAppended);
+                                    let _ = wake_tx.send(());
+                                    last_chat_list_update = now;
+                                    needs_chat_list_update = false;
+                                } else {
+                                    needs_chat_list_update = true;
                                 }
                             }
                             // Update::Option(option) => {

--- a/src/tg/tg_context.rs
+++ b/src/tg/tg_context.rs
@@ -344,9 +344,13 @@ impl TgContext {
         None
     }
 
+    /// Build the main chat list for the UI. Lock `chats` before `chats_index`: the TDLib update
+    /// task takes `chats` then `chats_index` when applying position updates; the previous
+    /// opposite order here could deadlock after a large catch-up when the UI rebuilt the list
+    /// concurrently with incoming updates.
     pub fn get_chats_index(&self) -> Result<Option<Vec<ChatListEntry>>, AppError<Event>> {
-        let chats_index = self.chats_index();
         let chats = self.chats();
+        let chats_index = self.chats_index();
         let mut chat_list: Vec<ChatListEntry> = Vec::new();
         for ord_chat in chats_index.iter() {
             let mut chat_list_item = ChatListEntry::new();


### PR DESCRIPTION
## Summary
- Rebases `startup-hang-fixes` onto `upstream/main`.
- Aligns `tdlib-rs` build-dependency to `1.4.0`.
- Adds `static-download` feature (`static` + `download-tdlib`) to enable one-shot static linking.
- Updates CI workflows (Android/Linux/macOS/Windows) to use `static-download` and adjusts related conditionals.

## Notes
- Android cross builds still require the NDK toolchain in CI; local cross builds need the same env.