### PR TITLE
fix(keymap): make prompt send key configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Occasional startup hangs and chat list refresh hangs.
 - Chat search reliability and clearer failure feedback via the status bar.
 - `q` incorrectly triggering quit while typing in the prompt (context-aware key handling).
+- The prompt send shortcut is configurable as `prompt_send_message`, allowing terminals that reserve `Alt+Enter` to use another key.
 - Chat list: scrolling, unread badge refresh when opening chats, refresh on launch, wrong unread count when a message arrives in the open chat, updates after server-side deletes, and `DeleteMessages` from cache vs real deletes.
 - Duplicate last message when scrolling; chat history performance regressions; config creation/loading issues; popup and list quirks.
 - Reply flow, reply styling, and copying messages with history restore.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -116,7 +116,7 @@ _Prompt_
 Note that when the prompt is focused, you can **NOT** use `q` or `ctrl+c` to quit the application, you need to press `esc` to return to the "None" state.
 
 ```bash
-alt+enter:                        Send the message
+alt+enter:                        Send the message (configurable as `prompt_send_message`)
 
 left | right | up | down:         Move the cursor
 ctrl+left | ctrl+b:               Move the cursor to the previous word

--- a/config/keymap.toml
+++ b/config/keymap.toml
@@ -110,6 +110,8 @@ keymap = [
 # Only list prompt-specific bindings here.
 [prompt]
 keymap = [
+  # Send the current message, edit, reply, or search.
+  { keys = ["alt+enter"], command = "prompt_send_message", description = "Send the message"},
   # Copy the selected text (overrides core_window try_quit when prompt focused)
   { keys = ["ctrl+c"], command = "prompt_copy", description = "Copy the selected text"},
   # Focus chat list / chat (so Alt+arrows work even if keymap lookup fails, e.g. terminal escape)

--- a/docs/configuration/keymap.toml.md
+++ b/docs/configuration/keymap.toml.md
@@ -80,7 +80,17 @@ keymap = [
 # The prompt key bindings are only usable in the prompt component.
 # When the prompt is focused, the prompt key bindings will be active.
 [prompt]
-keymap = []
+keymap = [
+  # Send the current message, edit, reply, or search.
+  { keys = ["alt+enter"], command = "prompt_send_message", description = "Send the message"},
+  # Copy the selected text
+  { keys = ["ctrl+c"], command = "prompt_copy", description = "Copy the selected text"},
+  # Focus chat list / chat
+  { keys = ["alt+left"], command = "focus_chat_list", description = "Focus the chat list"},
+  { keys = ["alt+right"], command = "focus_chat", description = "Focus the chat"},
+  # Open message search
+  { keys = ["alt+r"], command = "chat_window_search", description = "Open message search overlay"},
+]
 
 [file_upload_explorer]
 keymap = [
@@ -90,6 +100,23 @@ keymap = [
 ]
 
 ```
+
+## Rebinding message sending
+
+The `prompt_send_message` command controls the key used to send the current
+message, edit, reply, or search. To avoid a terminal-reserved shortcut such as
+`Alt+Enter` on Windows, bind the command to another key in your custom
+`keymap.toml`:
+
+```toml
+[prompt]
+keymap = [
+  { keys = ["ctrl+enter"], command = "prompt_send_message", description = "Send the message"},
+]
+```
+
+Keymaps are merged by command name, so this custom entry replaces the default
+`Alt+Enter` binding instead of adding a second send binding.
 
 ## Custom configuration
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -291,6 +291,8 @@ pub enum Action {
 
     /// StatusMessage: short message to show in the status bar (e.g. "Message yanked").
     StatusMessage(String),
+    /// Send the prompt contents using the current prompt mode.
+    PromptSendMessage,
     /// PromptCopy: copy selected text in the prompt (overrides try_quit when prompt focused).
     PromptCopy,
 
@@ -376,6 +378,7 @@ impl FromStr for Action {
             "show_theme_selector" => Ok(Action::ShowThemeSelector),
             "hide_theme_selector" => Ok(Action::HideThemeSelector),
             "switch_theme" => Ok(Action::SwitchTheme),
+            "prompt_send_message" => Ok(Action::PromptSendMessage),
             "prompt_copy" => Ok(Action::PromptCopy),
             "close_search_overlay" => Ok(Action::CloseSearchOverlay),
             "show_search_overlay" => Ok(Action::ShowSearchOverlay),

--- a/src/components/core_window.rs
+++ b/src/components/core_window.rs
@@ -340,7 +340,7 @@ impl HandleFocus for CoreWindow {
 impl Component for CoreWindow {
     fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> std::io::Result<()> {
         self.action_tx = Some(tx.clone());
-        for (_, component) in self.components.iter_mut() {
+        for component in self.components.values_mut() {
             component.register_action_handler(tx.clone())?;
         }
         Ok(())
@@ -429,7 +429,7 @@ impl Component for CoreWindow {
                 self.show_file_upload_explorer = false;
                 self.show_file_download_explorer = false;
                 self.show_pinned_messages_popup = false;
-                for (_, component) in self.components.iter_mut() {
+                for component in self.components.values_mut() {
                     component.unfocus();
                 }
             }

--- a/src/components/prompt_window.rs
+++ b/src/components/prompt_window.rs
@@ -724,6 +724,10 @@ impl Component for PromptWindow {
 
     fn update(&mut self, action: Action) {
         match action {
+            Action::PromptSendMessage => {
+                self.input.unselect_all();
+                self.input.send_message(Arc::clone(&self.app_context));
+            }
             Action::PromptCopy => {
                 self.input.copy_selected();
                 self.input.unselect_all();
@@ -855,11 +859,6 @@ impl Component for PromptWindow {
                 (KeyCode::Right | KeyCode::Char('f'), Modifiers { control: true, .. }) => {
                     self.input.unselect_all();
                     self.input.move_cursor_to_next_word();
-                }
-
-                (KeyCode::Enter, Modifiers { alt: true, .. }) => {
-                    self.input.unselect_all();
-                    self.input.send_message(Arc::clone(&self.app_context));
                 }
 
                 (KeyCode::Backspace, Modifiers { control: true, .. })
@@ -1178,5 +1177,70 @@ mod tests {
                 .collect::<String>(),
             "q"
         );
+    }
+    #[test]
+    fn configured_prompt_send_action_sends_current_text() {
+        use crate::configs::{
+            custom::keymap_custom::{ActionBinding, KeymapConfig},
+            raw::keymap_raw::KeymapRaw,
+        };
+
+        let raw: KeymapRaw = toml::from_str(include_str!("../../config/keymap.toml")).unwrap();
+        let keymap = KeymapConfig::from(raw);
+        let event = Event::Key(KeyCode::Enter, KeyModifiers::ALT);
+        let send_action = match keymap.get_map_of(Some(ComponentName::Prompt)).get(&event) {
+            Some(ActionBinding::Single { action, .. }) => action.clone(),
+            binding => panic!("expected alt+enter prompt binding, got {binding:?}"),
+        };
+        assert_eq!(send_action, Action::PromptSendMessage);
+
+        let app_context = create_test_app_context();
+        let (event_tx, mut event_rx) = unbounded_channel();
+        app_context.tg_context().set_event_tx(event_tx);
+
+        let mut window = PromptWindow::new(Arc::clone(&app_context));
+        let (action_tx, _action_rx) = unbounded_channel();
+        window.register_action_handler(action_tx).unwrap();
+        let modifiers = Modifiers::from(KeyModifiers::empty());
+        window.update(Action::Key(KeyCode::Char('h'), modifiers.clone()));
+        window.update(Action::Key(KeyCode::Char('i'), modifiers));
+        window.update(send_action);
+
+        match event_rx.try_recv().unwrap() {
+            Event::SendMessage(text, None) => assert_eq!(text, "hi"),
+            event => panic!("expected send-message event, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_prompt_send_binding_replaces_default() {
+        use crate::configs::{
+            config_merge::merge_keymap_raw,
+            custom::keymap_custom::{ActionBinding, KeymapConfig},
+            raw::keymap_raw::KeymapRaw,
+        };
+
+        let default_raw: KeymapRaw =
+            toml::from_str(include_str!("../../config/keymap.toml")).unwrap();
+        let user_raw: KeymapRaw = toml::from_str(
+            r#"
+            [prompt]
+            keymap = [
+              { keys = ["ctrl+enter"], command = "prompt_send_message" },
+            ]
+            "#,
+        )
+        .unwrap();
+        let keymap = KeymapConfig::from(merge_keymap_raw(default_raw, Some(user_raw)));
+        let prompt_map = keymap.get_map_of(Some(ComponentName::Prompt));
+
+        assert!(!prompt_map.contains_key(&Event::Key(KeyCode::Enter, KeyModifiers::ALT)));
+        assert!(matches!(
+            prompt_map.get(&Event::Key(KeyCode::Enter, KeyModifiers::CONTROL)),
+            Some(ActionBinding::Single {
+                action: Action::PromptSendMessage,
+                ..
+            })
+        ));
     }
 }

--- a/src/configs/custom/keymap_custom.rs
+++ b/src/configs/custom/keymap_custom.rs
@@ -761,28 +761,28 @@ mod tests {
         // prompt can be empty, so no assertion needed (len() >= 0 is always true)
 
         // Verify that all keybindings are valid (no Unknown events)
-        for (event, _binding) in keymap_config.core_window.iter() {
+        for event in keymap_config.core_window.keys() {
             assert_ne!(
                 *event,
                 Event::Unknown,
                 "core_window should not have Unknown events"
             );
         }
-        for (event, _binding) in keymap_config.chat_list.iter() {
+        for event in keymap_config.chat_list.keys() {
             assert_ne!(
                 *event,
                 Event::Unknown,
                 "chat_list should not have Unknown events"
             );
         }
-        for (event, _binding) in keymap_config.chat.iter() {
+        for event in keymap_config.chat.keys() {
             assert_ne!(
                 *event,
                 Event::Unknown,
                 "chat should not have Unknown events"
             );
         }
-        for (event, _binding) in keymap_config.prompt.iter() {
+        for event in keymap_config.prompt.keys() {
             assert_ne!(
                 *event,
                 Event::Unknown,


### PR DESCRIPTION
Fixes #201.

## Summary

Moves prompt message sending from hardcoded `Alt+Enter` handling to the configurable `prompt_send_message` action in the `[prompt]` keymap. `Alt+Enter` remains the default, while user configurations can replace it with another shortcut. Existing behavior for messages, edits, replies, and searches is preserved.