### PR TITLE
feat: add proxy support (SOCKS5 / HTTP / MTProto)

### DIFF
--- a/config/telegram.toml
+++ b/config/telegram.toml
@@ -38,3 +38,20 @@ verbosity_level = 2
 log_path = ".data/tdlib_rs/tdlib_rs.log"
 # Pass true to additionally redirect stderr to the log file. Ignored on Windows
 redirect_stderr = false
+# =========== proxy ===========
+# Optional proxy for connecting to Telegram. Uncomment and fill in to enable.
+# [proxy]
+# Proxy type: "socks5", "http", or "mtproto"
+# type = "socks5"
+# Proxy server address (domain or IP)
+# server = "127.0.0.1"
+# Proxy server port
+# port = 1080
+# Username for SOCKS5/HTTP proxy (optional, can be omitted)
+# username = ""
+# Password for SOCKS5/HTTP proxy (optional, can be omitted)
+# password = ""
+# HTTP proxy only: set to true if the proxy handles only HTTP requests (no CONNECT tunneling)
+# http_only = false
+# MTProto proxy only: hex-encoded secret
+# secret = ""

--- a/src/configs/custom/telegram_custom.rs
+++ b/src/configs/custom/telegram_custom.rs
@@ -524,4 +524,256 @@ mod tests {
             crate::configs::config_type::ConfigType::Telegram
         );
     }
+
+    // ── Proxy tests ──
+
+    use crate::configs::{
+        custom::telegram_custom::{ProxyConfig, ProxyType},
+        raw::telegram_raw::ProxyRaw,
+    };
+
+    #[test]
+    fn test_proxy_from_raw_socks5() {
+        let raw = ProxyRaw {
+            r#type: Some("socks5".into()),
+            server: Some("10.0.0.1".into()),
+            port: Some(1080),
+            username: Some("user".into()),
+            password: Some("pass".into()),
+            http_only: None,
+            secret: None,
+        };
+        let cfg: ProxyConfig = raw.into();
+        assert_eq!(cfg.r#type, ProxyType::Socks5);
+        assert_eq!(cfg.server, "10.0.0.1");
+        assert_eq!(cfg.port, 1080);
+        assert_eq!(cfg.username, "user");
+        assert_eq!(cfg.password, "pass");
+    }
+
+    #[test]
+    fn test_proxy_from_raw_http() {
+        let raw = ProxyRaw {
+            r#type: Some("http".into()),
+            server: Some("proxy.example.com".into()),
+            port: Some(3128),
+            username: Some("u".into()),
+            password: Some("p".into()),
+            http_only: Some(true),
+            secret: None,
+        };
+        let cfg: ProxyConfig = raw.into();
+        assert_eq!(cfg.r#type, ProxyType::Http);
+        assert_eq!(cfg.server, "proxy.example.com");
+        assert_eq!(cfg.port, 3128);
+        assert!(cfg.http_only);
+    }
+
+    #[test]
+    fn test_proxy_from_raw_mtproto() {
+        let raw = ProxyRaw {
+            r#type: Some("mtproto".into()),
+            server: Some("mtp.example.com".into()),
+            port: Some(443),
+            username: None,
+            password: None,
+            http_only: None,
+            secret: Some("deadbeef".into()),
+        };
+        let cfg: ProxyConfig = raw.into();
+        assert_eq!(cfg.r#type, ProxyType::Mtproto);
+        assert_eq!(cfg.secret, "deadbeef");
+    }
+
+    #[test]
+    fn test_proxy_from_raw_unknown_type_defaults_to_socks5() {
+        let raw = ProxyRaw {
+            r#type: Some("invalid".into()),
+            server: Some("127.0.0.1".into()),
+            port: Some(9999),
+            username: None,
+            password: None,
+            http_only: None,
+            secret: None,
+        };
+        let cfg: ProxyConfig = raw.into();
+        assert_eq!(cfg.r#type, ProxyType::Socks5);
+    }
+
+    #[test]
+    fn test_proxy_from_raw_defaults() {
+        let raw = ProxyRaw {
+            r#type: None,
+            server: None,
+            port: None,
+            username: None,
+            password: None,
+            http_only: None,
+            secret: None,
+        };
+        let cfg: ProxyConfig = raw.into();
+        assert_eq!(cfg.r#type, ProxyType::Socks5);
+        assert_eq!(cfg.server, "");
+        assert_eq!(cfg.port, 1080);
+        assert_eq!(cfg.username, "");
+        assert_eq!(cfg.password, "");
+        assert!(!cfg.http_only);
+        assert_eq!(cfg.secret, "");
+    }
+
+    #[test]
+    fn test_telegram_from_raw_with_proxy() {
+        let telegram_raw = TelegramRaw {
+            api_id: Some("1".into()),
+            api_hash: Some("h".into()),
+            database_dir: Some(".data/tg".into()),
+            use_file_database: Some(true),
+            use_chat_info_database: Some(true),
+            use_message_database: Some(true),
+            system_language_code: Some("en".into()),
+            device_model: Some("Desktop".into()),
+            verbosity_level: Some(2),
+            log_path: Some(".data/tdlib_rs/tdlib_rs.log".into()),
+            redirect_stderr: Some(false),
+            proxy: Some(ProxyRaw {
+                r#type: Some("socks5".into()),
+                server: Some("10.0.0.1".into()),
+                port: Some(1080),
+                username: None,
+                password: None,
+                http_only: None,
+                secret: None,
+            }),
+        };
+        let cfg = TelegramConfig::from(telegram_raw);
+        assert!(cfg.proxy.is_some());
+        let p = cfg.proxy.unwrap();
+        assert_eq!(p.r#type, ProxyType::Socks5);
+        assert_eq!(p.server, "10.0.0.1");
+        assert_eq!(p.port, 1080);
+    }
+
+    #[test]
+    fn test_telegram_from_raw_proxy_empty_server() {
+        let telegram_raw = TelegramRaw {
+            api_id: Some("1".into()),
+            api_hash: Some("h".into()),
+            database_dir: Some(".data/tg".into()),
+            use_file_database: Some(true),
+            use_chat_info_database: Some(true),
+            use_message_database: Some(true),
+            system_language_code: Some("en".into()),
+            device_model: Some("Desktop".into()),
+            verbosity_level: Some(2),
+            log_path: Some(".data/tdlib_rs/tdlib_rs.log".into()),
+            redirect_stderr: Some(false),
+            proxy: Some(ProxyRaw {
+                r#type: Some("socks5".into()),
+                server: Some("".into()),
+                port: Some(1080),
+                username: None,
+                password: None,
+                http_only: None,
+                secret: None,
+            }),
+        };
+        let cfg = TelegramConfig::from(telegram_raw);
+        assert!(cfg.proxy.is_none());
+    }
+
+    #[test]
+    fn test_telegram_merge_sets_proxy() {
+        let mut cfg = TelegramConfig {
+            api_id: "1".into(),
+            api_hash: "h".into(),
+            database_dir: ".data/tg".into(),
+            use_file_database: true,
+            use_chat_info_database: true,
+            use_message_database: true,
+            system_language_code: "en".into(),
+            device_model: "Desktop".into(),
+            verbosity_level: 2,
+            log_path: ".data/tdlib_rs/tdlib_rs.log".into(),
+            redirect_stderr: false,
+            proxy: None,
+        };
+        let raw = TelegramRaw {
+            api_id: None,
+            api_hash: None,
+            database_dir: None,
+            use_file_database: None,
+            use_chat_info_database: None,
+            use_message_database: None,
+            system_language_code: None,
+            device_model: None,
+            verbosity_level: None,
+            log_path: None,
+            redirect_stderr: None,
+            proxy: Some(ProxyRaw {
+                r#type: Some("http".into()),
+                server: Some("proxy:8080".into()),
+                port: Some(8080),
+                username: None,
+                password: None,
+                http_only: Some(true),
+                secret: None,
+            }),
+        };
+        let merged = cfg.merge(Some(raw));
+        assert!(merged.proxy.is_some());
+        let p = merged.proxy.unwrap();
+        assert_eq!(p.r#type, ProxyType::Http);
+        assert_eq!(p.server, "proxy:8080");
+        assert!(p.http_only);
+    }
+
+    #[test]
+    fn test_telegram_merge_proxy_empty_server_clears() {
+        let mut cfg = TelegramConfig {
+            api_id: "1".into(),
+            api_hash: "h".into(),
+            database_dir: ".data/tg".into(),
+            use_file_database: true,
+            use_chat_info_database: true,
+            use_message_database: true,
+            system_language_code: "en".into(),
+            device_model: "Desktop".into(),
+            verbosity_level: 2,
+            log_path: ".data/tdlib_rs/tdlib_rs.log".into(),
+            redirect_stderr: false,
+            proxy: Some(ProxyConfig {
+                r#type: ProxyType::Socks5,
+                server: "10.0.0.1".into(),
+                port: 1080,
+                username: "".into(),
+                password: "".into(),
+                http_only: false,
+                secret: "".into(),
+            }),
+        };
+        let raw = TelegramRaw {
+            api_id: None,
+            api_hash: None,
+            database_dir: None,
+            use_file_database: None,
+            use_chat_info_database: None,
+            use_message_database: None,
+            system_language_code: None,
+            device_model: None,
+            verbosity_level: None,
+            log_path: None,
+            redirect_stderr: None,
+            proxy: Some(ProxyRaw {
+                r#type: Some("socks5".into()),
+                server: Some("".into()),
+                port: Some(1080),
+                username: None,
+                password: None,
+                http_only: None,
+                secret: None,
+            }),
+        };
+        let merged = cfg.merge(Some(raw));
+        assert!(merged.proxy.is_none());
+    }
 }

--- a/src/configs/custom/telegram_custom.rs
+++ b/src/configs/custom/telegram_custom.rs
@@ -1,12 +1,61 @@
 use crate::{
     app_error::AppError,
     configs::{
-        self, config_file::ConfigFile, config_type::ConfigType, raw::telegram_raw::TelegramRaw,
+        self,
+        config_file::ConfigFile,
+        config_type::ConfigType,
+        raw::telegram_raw::{ProxyRaw, TelegramRaw},
     },
     utils,
 };
 use std::path::Path;
 use std::path::PathBuf;
+
+#[derive(Clone, Debug, PartialEq)]
+/// The proxy type.
+pub enum ProxyType {
+    Socks5,
+    Http,
+    Mtproto,
+}
+
+#[derive(Clone, Debug)]
+/// The proxy configuration.
+pub struct ProxyConfig {
+    /// Proxy type.
+    pub r#type: ProxyType,
+    /// Proxy server domain or IP address.
+    pub server: String,
+    /// Proxy server port.
+    pub port: i32,
+    /// Username for SOCKS5 or HTTP proxy (empty if unused).
+    pub username: String,
+    /// Password for SOCKS5 or HTTP proxy (empty if unused).
+    pub password: String,
+    /// HTTP proxy only: true if the proxy supports only HTTP requests.
+    pub http_only: bool,
+    /// MTProto proxy only: hex-encoded secret (empty if unused).
+    pub secret: String,
+}
+
+impl From<ProxyRaw> for ProxyConfig {
+    fn from(raw: ProxyRaw) -> Self {
+        let proxy_type = match raw.r#type.as_deref() {
+            Some("http") => ProxyType::Http,
+            Some("mtproto") => ProxyType::Mtproto,
+            _ => ProxyType::Socks5,
+        };
+        Self {
+            r#type: proxy_type,
+            server: raw.server.unwrap_or_default(),
+            port: raw.port.unwrap_or(1080),
+            username: raw.username.unwrap_or_default(),
+            password: raw.password.unwrap_or_default(),
+            http_only: raw.http_only.unwrap_or(false),
+            secret: raw.secret.unwrap_or_default(),
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 /// The telegram configuration.
@@ -37,6 +86,8 @@ pub struct TelegramConfig {
     pub log_path: String,
     /// A flag that indicates if the log to stderr should be also redirected.
     pub redirect_stderr: bool,
+    /// Optional proxy configuration.
+    pub proxy: Option<ProxyConfig>,
 }
 /// The telegram configuration implementation.
 impl TelegramConfig {
@@ -122,6 +173,21 @@ impl ConfigFile for TelegramConfig {
                 if let Some(redirect_stderr) = _other.redirect_stderr {
                     self.redirect_stderr = redirect_stderr;
                 }
+                if let Some(proxy_raw) = _other.proxy {
+                    let config: ProxyConfig = proxy_raw.into();
+                    if !config.server.is_empty() {
+                        tracing::info!(
+                            "Proxy configured: {:?} {}:{}",
+                            config.r#type,
+                            config.server,
+                            config.port
+                        );
+                        self.proxy = Some(config);
+                    } else {
+                        tracing::info!("Proxy section present but server is empty, skipping");
+                        self.proxy = None;
+                    }
+                }
                 self.clone()
             }
         }
@@ -191,6 +257,15 @@ impl From<TelegramRaw> for TelegramConfig {
             }
         }
 
+        let proxy = raw.proxy.and_then(|p| {
+            let config: ProxyConfig = p.into();
+            if config.server.is_empty() {
+                None
+            } else {
+                Some(config)
+            }
+        });
+
         Self {
             api_id: raw.api_id.unwrap(),
             api_hash: raw.api_hash.unwrap(),
@@ -203,6 +278,7 @@ impl From<TelegramRaw> for TelegramConfig {
             verbosity_level: raw.verbosity_level.unwrap(),
             log_path,
             redirect_stderr: raw.redirect_stderr.unwrap(),
+            proxy,
         }
     }
 }
@@ -238,6 +314,7 @@ mod tests {
             verbosity_level: Some(1),
             log_path: Some(".data/tdlib_rs/tdlib_rs.log".to_string()),
             redirect_stderr: Some(true),
+            proxy: None,
         };
         let telegram_config = TelegramConfig::from(telegram_raw);
         assert_eq!(telegram_config.api_id, "api_id");
@@ -281,6 +358,7 @@ mod tests {
             verbosity_level: 1,
             log_path: ".data/tdlib_rs/tdlib_rs.log".to_string(),
             redirect_stderr: false,
+            proxy: None,
         };
         let telegram_raw = TelegramRaw {
             api_id: Some("api_id_2".to_string()),
@@ -294,6 +372,7 @@ mod tests {
             verbosity_level: Some(2),
             log_path: None,
             redirect_stderr: Some(true),
+            proxy: None,
         };
         let telegram_config = telegram_config.merge(Some(telegram_raw));
         assert_eq!(telegram_config.api_id, "api_id_2");
@@ -326,6 +405,7 @@ mod tests {
             verbosity_level: 1,
             log_path: ".data/tdlib_rs/tdlib_rs.log".to_string(),
             redirect_stderr: false,
+            proxy: None,
         };
         let telegram_config = telegram_config.merge(None);
         assert_eq!(telegram_config.api_id, "api_id");
@@ -355,6 +435,7 @@ mod tests {
             verbosity_level: 1,
             log_path: ".data/tdlib_rs/tdlib_rs.log".to_string(),
             redirect_stderr: false,
+            proxy: None,
         };
         let telegram_raw = TelegramRaw {
             api_id: Some("api_id_2".to_string()),
@@ -368,6 +449,7 @@ mod tests {
             verbosity_level: None,
             log_path: None,
             redirect_stderr: Some(true),
+            proxy: None,
         };
         let telegram_config = telegram_config.merge(Some(telegram_raw));
         assert_eq!(telegram_config.api_id, "api_id_2");
@@ -402,6 +484,7 @@ mod tests {
             verbosity_level: 1,
             log_path: ".data/tdlib_rs/tdlib_rs.log".to_string(),
             redirect_stderr: false,
+            proxy: None,
         };
         let telegram_raw = TelegramRaw {
             api_id: Some("api_id_2".to_string()),
@@ -415,6 +498,7 @@ mod tests {
             verbosity_level: Some(2),
             log_path: None,
             redirect_stderr: Some(true),
+            proxy: None,
         };
         let telegram_config = telegram_config.merge(Some(telegram_raw));
         assert_eq!(telegram_config.api_id, "api_id_2");

--- a/src/configs/raw/telegram_raw.rs
+++ b/src/configs/raw/telegram_raw.rs
@@ -1,6 +1,25 @@
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]
+/// The proxy raw configuration.
+pub struct ProxyRaw {
+    /// Proxy type: "socks5", "http", or "mtproto".
+    pub r#type: Option<String>,
+    /// Proxy server domain or IP address.
+    pub server: Option<String>,
+    /// Proxy server port.
+    pub port: Option<i32>,
+    /// Username for SOCKS5 or HTTP proxy (optional).
+    pub username: Option<String>,
+    /// Password for SOCKS5 or HTTP proxy (optional).
+    pub password: Option<String>,
+    /// HTTP proxy only: true if the proxy supports only HTTP requests.
+    pub http_only: Option<bool>,
+    /// MTProto proxy only: hex-encoded secret.
+    pub secret: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
 /// The telegram raw configuration.
 pub struct TelegramRaw {
     /// The API ID.
@@ -29,4 +48,6 @@ pub struct TelegramRaw {
     pub log_path: Option<String>,
     /// A flag that indicates if the log to stderr should be also redirected.
     pub redirect_stderr: Option<bool>,
+    /// Optional proxy configuration.
+    pub proxy: Option<ProxyRaw>,
 }

--- a/src/tg/tg_backend.rs
+++ b/src/tg/tg_backend.rs
@@ -539,6 +539,57 @@ impl TgBackend {
         }
     }
 
+    /// Configure and enable the proxy from telegram config, if one is set.
+    async fn setup_proxy(&self, proxy_cfg: &crate::configs::custom::telegram_custom::ProxyConfig) {
+        if proxy_cfg.server.is_empty() {
+            tracing::info!("Proxy server is empty, skipping");
+            return;
+        }
+
+        tracing::info!(
+            "Setting up {:?} proxy: {}:{}",
+            proxy_cfg.r#type,
+            proxy_cfg.server,
+            proxy_cfg.port
+        );
+
+        let proxy_type = match proxy_cfg.r#type {
+            crate::configs::custom::telegram_custom::ProxyType::Socks5 => {
+                tdlib_rs::enums::ProxyType::Socks5(tdlib_rs::types::ProxyTypeSocks5 {
+                    username: proxy_cfg.username.clone(),
+                    password: proxy_cfg.password.clone(),
+                })
+            }
+            crate::configs::custom::telegram_custom::ProxyType::Http => {
+                tdlib_rs::enums::ProxyType::Http(tdlib_rs::types::ProxyTypeHttp {
+                    username: proxy_cfg.username.clone(),
+                    password: proxy_cfg.password.clone(),
+                    http_only: proxy_cfg.http_only,
+                })
+            }
+            crate::configs::custom::telegram_custom::ProxyType::Mtproto => {
+                tdlib_rs::enums::ProxyType::Mtproto(tdlib_rs::types::ProxyTypeMtproto {
+                    secret: proxy_cfg.secret.clone(),
+                })
+            }
+        };
+
+        let proxy = tdlib_rs::types::Proxy {
+            server: proxy_cfg.server.clone(),
+            port: proxy_cfg.port,
+            r#type: proxy_type,
+        };
+
+        match functions::add_proxy(proxy, true, self.client_id).await {
+            Ok(tdlib_rs::enums::AddedProxy::AddedProxy(added)) => {
+                tracing::info!("Proxy added and enabled: id={}", added.id);
+            }
+            Err(e) => {
+                tracing::error!("Failed to add proxy: {} (code: {})", e.message, e.code);
+            }
+        }
+    }
+
     #[allow(clippy::await_holding_lock)]
     pub async fn handle_authorization_state(&mut self) {
         tracing::info!("Handling authorization state");
@@ -584,6 +635,7 @@ impl TgBackend {
         let use_message_database = telegram_config.use_message_database;
         let system_language_code = telegram_config.system_language_code.clone();
         let device_model = telegram_config.device_model.clone();
+        let proxy_cfg = telegram_config.proxy.clone();
 
         while let Some(state) = self.auth_rx.recv().await {
             match state {
@@ -609,6 +661,11 @@ impl TgBackend {
 
                     if let Err(error) = response {
                         println!("{}", error.message);
+                    }
+
+                    // Set up proxy before TDLib establishes connections
+                    if let Some(ref cfg) = proxy_cfg {
+                        self.setup_proxy(cfg).await;
                     }
                 }
                 AuthorizationState::WaitPhoneNumber => loop {


### PR DESCRIPTION
Configure proxy via optional [proxy] section in telegram.toml. Proxy is set up right after set_tdlib_parameters, before any network connections are established, per TDLib API requirement.

Supported proxy types:
- socks5 (default)
- http (with optional http_only flag)
- mtproto (with hex-encoded secret)

Closes: #311